### PR TITLE
sen13680 driver minor update

### DIFF
--- a/drv_sen13680.c
+++ b/drv_sen13680.c
@@ -61,8 +61,7 @@ bool sen13680_init()
   }
   if (!success)
   {
-    //257 is the default value returned when the lidar isnt connected
-    distance = 257;
+    distance = -1;
   }
   return success;
 }

--- a/drv_sen13680.c
+++ b/drv_sen13680.c
@@ -59,6 +59,11 @@ bool sen13680_init()
   {
     success = false;
   }
+  if (!success)
+  {
+    //257 is the default value returned when the lidar isnt connected
+    distance = 257;
+  }
   return success;
 }
 


### PR DESCRIPTION
If sen13680 initialization fails, distance is set to the default read-failure value of 257, which makes board implementation easier and more robust. If its better to keep the driver alone, I could instead change a few things in board.c