### PR TITLE
Fix for airspeed sensor locking up the naze

### DIFF
--- a/drv_ms4525.c
+++ b/drv_ms4525.c
@@ -162,7 +162,7 @@ void ms4525_async_update(void)
   else
   {
     i2c_queue_job(READ, MS4525_ADDR, 0xFF, buf, 4, &read_status, &ms4525_read_CB);
-    next_update_ms += 1; // Poll at 1000 Hz
+    next_update_ms += 20; // Poll at 50 Hz
   }
   return;
 }


### PR DESCRIPTION
The airspeed sensor was being polled too frequently (1000Hz) which the naze couldn't keep up with and still communicate with the computer, so changing that to 50Hz fixed the issue. It ran successfully over the weekend with no errors. (Tim Whiting from the senior project class committed and fixed the issue)