### PR TITLE
various typos in comments

### DIFF
--- a/lib/CMSIS/CM3/DeviceSupport/ST/STM32F10x/stm32f10x.h
+++ b/lib/CMSIS/CM3/DeviceSupport/ST/STM32F10x/stm32f10x.h
@@ -4,26 +4,26 @@
   * @author  MCD Application Team
   * @version V3.5.0
   * @date    11-March-2011
-  * @brief   CMSIS Cortex-M3 Device Peripheral Access Layer Header File. 
-  *          This file contains all the peripheral register's definitions, bits 
-  *          definitions and memory mapping for STM32F10x Connectivity line, 
-  *          High density, High density value line, Medium density, 
-  *          Medium density Value line, Low density, Low density Value line 
+  * @brief   CMSIS Cortex-M3 Device Peripheral Access Layer Header File.
+  *          This file contains all the peripheral register's definitions, bits
+  *          definitions and memory mapping for STM32F10x Connectivity line,
+  *          High density, High density value line, Medium density,
+  *          Medium density Value line, Low density, Low density Value line
   *          and XL-density devices.
   *
   *          The file is the unique include file that the application programmer
   *          is using in the C source code, usually in main.c. This file contains:
   *           - Configuration section that allows to select:
   *              - The device used in the target application
-  *              - To use or not the peripheral’s drivers in application code(i.e. 
-  *                code will be based on direct access to peripheral’s registers 
-  *                rather than drivers API), this option is controlled by 
+  *              - To use or not the peripheral's drivers in application code(i.e.
+  *                code will be based on direct access to peripheral's registers
+  *                rather than drivers API), this option is controlled by
   *                "#define USE_STDPERIPH_DRIVER"
-  *              - To change few application-specific parameters such as the HSE 
+  *              - To change few application-specific parameters such as the HSE
   *                crystal frequency
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripheral's registers hardware
   *
   ******************************************************************************
   * @attention
@@ -46,29 +46,29 @@
 /** @addtogroup stm32f10x
   * @{
   */
-    
+
 #ifndef __STM32F10x_H
 #define __STM32F10x_H
 
 #ifdef __cplusplus
  extern "C" {
-#endif 
-  
+#endif
+
 /** @addtogroup Library_configuration_section
   * @{
   */
-  
+
 /* Uncomment the line below according to the target STM32 device used in your
-   application 
+   application
   */
 
-#if !defined (STM32F10X_LD) && !defined (STM32F10X_LD_VL) && !defined (STM32F10X_MD) && !defined (STM32F10X_MD_VL) && !defined (STM32F10X_HD) && !defined (STM32F10X_HD_VL) && !defined (STM32F10X_XL) && !defined (STM32F10X_CL) 
+#if !defined (STM32F10X_LD) && !defined (STM32F10X_LD_VL) && !defined (STM32F10X_MD) && !defined (STM32F10X_MD_VL) && !defined (STM32F10X_HD) && !defined (STM32F10X_HD_VL) && !defined (STM32F10X_XL) && !defined (STM32F10X_CL)
   /* #define STM32F10X_LD */     /*!< STM32F10X_LD: STM32 Low density devices */
-  /* #define STM32F10X_LD_VL */  /*!< STM32F10X_LD_VL: STM32 Low density Value Line devices */  
+  /* #define STM32F10X_LD_VL */  /*!< STM32F10X_LD_VL: STM32 Low density Value Line devices */
   /* #define STM32F10X_MD */     /*!< STM32F10X_MD: STM32 Medium density devices */
-  /* #define STM32F10X_MD_VL */  /*!< STM32F10X_MD_VL: STM32 Medium density Value Line devices */  
+  /* #define STM32F10X_MD_VL */  /*!< STM32F10X_MD_VL: STM32 Medium density Value Line devices */
   /* #define STM32F10X_HD */     /*!< STM32F10X_HD: STM32 High density devices */
-  /* #define STM32F10X_HD_VL */  /*!< STM32F10X_HD_VL: STM32 High density value line devices */  
+  /* #define STM32F10X_HD_VL */  /*!< STM32F10X_HD_VL: STM32 High density value line devices */
   /* #define STM32F10X_XL */     /*!< STM32F10X_XL: STM32 XL-density devices */
   /* #define STM32F10X_CL */     /*!< STM32F10X_CL: STM32 Connectivity line devices */
 #endif
@@ -81,12 +81,12 @@
    memory density ranges between 16 and 32 Kbytes.
  - Medium-density devices are STM32F101xx, STM32F102xx and STM32F103xx microcontrollers
    where the Flash memory density ranges between 64 and 128 Kbytes.
- - Medium-density value line devices are STM32F100xx microcontrollers where the 
-   Flash memory density ranges between 64 and 128 Kbytes.   
+ - Medium-density value line devices are STM32F100xx microcontrollers where the
+   Flash memory density ranges between 64 and 128 Kbytes.
  - High-density devices are STM32F101xx and STM32F103xx microcontrollers where
    the Flash memory density ranges between 256 and 512 Kbytes.
- - High-density value line devices are STM32F100xx microcontrollers where the 
-   Flash memory density ranges between 256 and 512 Kbytes.   
+ - High-density value line devices are STM32F100xx microcontrollers where the
+   Flash memory density ranges between 256 and 512 Kbytes.
  - XL-density devices are STM32F101xx and STM32F103xx microcontrollers where
    the Flash memory density ranges between 512 and 1024 Kbytes.
  - Connectivity line devices are STM32F105xx and STM32F107xx microcontrollers.
@@ -99,31 +99,31 @@
 #if !defined  USE_STDPERIPH_DRIVER
 /**
  * @brief Comment the line below if you will not use the peripherals drivers.
-   In this case, these drivers will not be included and the application code will 
-   be based on direct access to peripherals registers 
+   In this case, these drivers will not be included and the application code will
+   be based on direct access to peripherals registers
    */
   /*#define USE_STDPERIPH_DRIVER*/
 #endif
 
 /**
  * @brief In the following line adjust the value of External High Speed oscillator (HSE)
-   used in your application 
-   
+   used in your application
+
    Tip: To avoid modifying this file each time you need to use different HSE, you
         can define the HSE value in your toolchain compiler preprocessor.
-  */           
+  */
 #if !defined  HSE_VALUE
- #ifdef STM32F10X_CL   
+ #ifdef STM32F10X_CL
   #define HSE_VALUE    ((uint32_t)25000000) /*!< Value of the External oscillator in Hz */
- #else 
+ #else
   #define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
  #endif /* STM32F10X_CL */
 #endif /* HSE_VALUE */
 
 
 /**
- * @brief In the following line adjust the External High Speed oscillator (HSE) Startup 
-   Timeout value 
+ * @brief In the following line adjust the External High Speed oscillator (HSE) Startup
+   Timeout value
    */
 #define HSE_STARTUP_TIMEOUT   ((uint16_t)0x0500) /*!< Time out for HSE start up */
 
@@ -132,10 +132,10 @@
 /**
  * @brief STM32F10x Standard Peripheral Library version number
    */
-#define __STM32F10X_STDPERIPH_VERSION_MAIN   (0x03) /*!< [31:24] main version */                                  
+#define __STM32F10X_STDPERIPH_VERSION_MAIN   (0x03) /*!< [31:24] main version */
 #define __STM32F10X_STDPERIPH_VERSION_SUB1   (0x05) /*!< [23:16] sub1 version */
 #define __STM32F10X_STDPERIPH_VERSION_SUB2   (0x00) /*!< [15:8]  sub2 version */
-#define __STM32F10X_STDPERIPH_VERSION_RC     (0x00) /*!< [7:0]  release candidate */ 
+#define __STM32F10X_STDPERIPH_VERSION_RC     (0x00) /*!< [7:0]  release candidate */
 #define __STM32F10X_STDPERIPH_VERSION       ( (__STM32F10X_STDPERIPH_VERSION_MAIN << 24)\
                                              |(__STM32F10X_STDPERIPH_VERSION_SUB1 << 16)\
                                              |(__STM32F10X_STDPERIPH_VERSION_SUB2 << 8)\
@@ -150,7 +150,7 @@
   */
 
 /**
- * @brief Configuration of the Cortex-M3 Processor and Core Peripherals 
+ * @brief Configuration of the Cortex-M3 Processor and Core Peripherals
  */
 #ifdef STM32F10X_XL
  #define __MPU_PRESENT             1 /*!< STM32 XL-density devices provide an MPU */
@@ -161,8 +161,8 @@
 #define __Vendor_SysTickConfig    0 /*!< Set to 1 if different SysTick Config is used */
 
 /**
- * @brief STM32F10x Interrupt Number Definition, according to the selected device 
- *        in @ref Library_configuration_section 
+ * @brief STM32F10x Interrupt Number Definition, according to the selected device
+ *        in @ref Library_configuration_section
  */
 typedef enum IRQn
 {
@@ -216,8 +216,8 @@ typedef enum IRQn
   USART2_IRQn                 = 38,     /*!< USART2 global Interrupt                              */
   EXTI15_10_IRQn              = 40,     /*!< External Line[15:10] Interrupts                      */
   RTCAlarm_IRQn               = 41,     /*!< RTC Alarm through EXTI Line Interrupt                */
-  USBWakeUp_IRQn              = 42      /*!< USB Device WakeUp from suspend through EXTI Line Interrupt */    
-#endif /* STM32F10X_LD */  
+  USBWakeUp_IRQn              = 42      /*!< USB Device WakeUp from suspend through EXTI Line Interrupt */
+#endif /* STM32F10X_LD */
 
 #ifdef STM32F10X_LD_VL
   ADC1_IRQn                   = 18,     /*!< ADC1 global Interrupt                                */
@@ -237,7 +237,7 @@ typedef enum IRQn
   RTCAlarm_IRQn               = 41,     /*!< RTC Alarm through EXTI Line Interrupt                */
   CEC_IRQn                    = 42,     /*!< HDMI-CEC Interrupt                                   */
   TIM6_DAC_IRQn               = 54,     /*!< TIM6 and DAC underrun Interrupt                      */
-  TIM7_IRQn                   = 55      /*!< TIM7 Interrupt                                       */       
+  TIM7_IRQn                   = 55      /*!< TIM7 Interrupt                                       */
 #endif /* STM32F10X_LD_VL */
 
 #ifdef STM32F10X_MD
@@ -265,8 +265,8 @@ typedef enum IRQn
   USART3_IRQn                 = 39,     /*!< USART3 global Interrupt                              */
   EXTI15_10_IRQn              = 40,     /*!< External Line[15:10] Interrupts                      */
   RTCAlarm_IRQn               = 41,     /*!< RTC Alarm through EXTI Line Interrupt                */
-  USBWakeUp_IRQn              = 42      /*!< USB Device WakeUp from suspend through EXTI Line Interrupt */  
-#endif /* STM32F10X_MD */  
+  USBWakeUp_IRQn              = 42      /*!< USB Device WakeUp from suspend through EXTI Line Interrupt */
+#endif /* STM32F10X_MD */
 
 #ifdef STM32F10X_MD_VL
   ADC1_IRQn                   = 18,     /*!< ADC1 global Interrupt                                */
@@ -291,7 +291,7 @@ typedef enum IRQn
   RTCAlarm_IRQn               = 41,     /*!< RTC Alarm through EXTI Line Interrupt                */
   CEC_IRQn                    = 42,     /*!< HDMI-CEC Interrupt                                   */
   TIM6_DAC_IRQn               = 54,     /*!< TIM6 and DAC underrun Interrupt                      */
-  TIM7_IRQn                   = 55      /*!< TIM7 Interrupt                                       */       
+  TIM7_IRQn                   = 55      /*!< TIM7 Interrupt                                       */
 #endif /* STM32F10X_MD_VL */
 
 #ifdef STM32F10X_HD
@@ -337,7 +337,7 @@ typedef enum IRQn
   DMA2_Channel2_IRQn          = 57,     /*!< DMA2 Channel 2 global Interrupt                      */
   DMA2_Channel3_IRQn          = 58,     /*!< DMA2 Channel 3 global Interrupt                      */
   DMA2_Channel4_5_IRQn        = 59      /*!< DMA2 Channel 4 and Channel 5 global Interrupt        */
-#endif /* STM32F10X_HD */  
+#endif /* STM32F10X_HD */
 
 #ifdef STM32F10X_HD_VL
   ADC1_IRQn                   = 18,     /*!< ADC1 global Interrupt                                */
@@ -367,16 +367,16 @@ typedef enum IRQn
   TIM5_IRQn                   = 50,     /*!< TIM5 global Interrupt                                */
   SPI3_IRQn                   = 51,     /*!< SPI3 global Interrupt                                */
   UART4_IRQn                  = 52,     /*!< UART4 global Interrupt                               */
-  UART5_IRQn                  = 53,     /*!< UART5 global Interrupt                               */  
+  UART5_IRQn                  = 53,     /*!< UART5 global Interrupt                               */
   TIM6_DAC_IRQn               = 54,     /*!< TIM6 and DAC underrun Interrupt                      */
-  TIM7_IRQn                   = 55,     /*!< TIM7 Interrupt                                       */  
+  TIM7_IRQn                   = 55,     /*!< TIM7 Interrupt                                       */
   DMA2_Channel1_IRQn          = 56,     /*!< DMA2 Channel 1 global Interrupt                      */
   DMA2_Channel2_IRQn          = 57,     /*!< DMA2 Channel 2 global Interrupt                      */
   DMA2_Channel3_IRQn          = 58,     /*!< DMA2 Channel 3 global Interrupt                      */
   DMA2_Channel4_5_IRQn        = 59,     /*!< DMA2 Channel 4 and Channel 5 global Interrupt        */
-  DMA2_Channel5_IRQn          = 60      /*!< DMA2 Channel 5 global Interrupt (DMA2 Channel 5 is 
-                                             mapped at position 60 only if the MISC_REMAP bit in 
-                                             the AFIO_MAPR2 register is set)                      */       
+  DMA2_Channel5_IRQn          = 60      /*!< DMA2 Channel 5 global Interrupt (DMA2 Channel 5 is
+                                             mapped at position 60 only if the MISC_REMAP bit in
+                                             the AFIO_MAPR2 register is set)                      */
 #endif /* STM32F10X_HD_VL */
 
 #ifdef STM32F10X_XL
@@ -422,7 +422,7 @@ typedef enum IRQn
   DMA2_Channel2_IRQn          = 57,     /*!< DMA2 Channel 2 global Interrupt                      */
   DMA2_Channel3_IRQn          = 58,     /*!< DMA2 Channel 3 global Interrupt                      */
   DMA2_Channel4_5_IRQn        = 59      /*!< DMA2 Channel 4 and Channel 5 global Interrupt        */
-#endif /* STM32F10X_XL */  
+#endif /* STM32F10X_XL */
 
 #ifdef STM32F10X_CL
   ADC1_2_IRQn                 = 18,     /*!< ADC1 and ADC2 global Interrupt                       */
@@ -468,7 +468,7 @@ typedef enum IRQn
   CAN2_RX1_IRQn               = 65,     /*!< CAN2 RX1 Interrupt                                   */
   CAN2_SCE_IRQn               = 66,     /*!< CAN2 SCE Interrupt                                   */
   OTG_FS_IRQn                 = 67      /*!< USB OTG FS global Interrupt                          */
-#endif /* STM32F10X_CL */     
+#endif /* STM32F10X_CL */
 } IRQn_Type;
 
 /**
@@ -481,7 +481,7 @@ typedef enum IRQn
 
 /** @addtogroup Exported_types
   * @{
-  */  
+  */
 
 /*!< STM32F10x Standard Peripheral Library old types (maintained for legacy purpose) */
 typedef int32_t  s32;
@@ -533,10 +533,10 @@ typedef enum {ERROR = 0, SUCCESS = !ERROR} ErrorStatus;
 
 /** @addtogroup Peripheral_registers_structures
   * @{
-  */   
+  */
 
-/** 
-  * @brief Analog to Digital Converter  
+/**
+  * @brief Analog to Digital Converter
   */
 
 typedef struct
@@ -563,8 +563,8 @@ typedef struct
   __IO uint32_t DR;
 } ADC_TypeDef;
 
-/** 
-  * @brief Backup Registers  
+/**
+  * @brief Backup Registers
   */
 
 typedef struct
@@ -589,7 +589,7 @@ typedef struct
   __IO uint16_t DR9;
   uint16_t  RESERVED9;
   __IO uint16_t DR10;
-  uint16_t  RESERVED10; 
+  uint16_t  RESERVED10;
   __IO uint16_t RTCCR;
   uint16_t  RESERVED11;
   __IO uint16_t CR;
@@ -635,7 +635,7 @@ typedef struct
   __IO uint16_t DR29;
   uint16_t  RESERVED32;
   __IO uint16_t DR30;
-  uint16_t  RESERVED33; 
+  uint16_t  RESERVED33;
   __IO uint16_t DR31;
   uint16_t  RESERVED34;
   __IO uint16_t DR32;
@@ -659,11 +659,11 @@ typedef struct
   __IO uint16_t DR41;
   uint16_t  RESERVED44;
   __IO uint16_t DR42;
-  uint16_t  RESERVED45;    
+  uint16_t  RESERVED45;
 } BKP_TypeDef;
-  
-/** 
-  * @brief Controller Area Network TxMailBox 
+
+/**
+  * @brief Controller Area Network TxMailBox
   */
 
 typedef struct
@@ -674,10 +674,10 @@ typedef struct
   __IO uint32_t TDHR;
 } CAN_TxMailBox_TypeDef;
 
-/** 
-  * @brief Controller Area Network FIFOMailBox 
+/**
+  * @brief Controller Area Network FIFOMailBox
   */
-  
+
 typedef struct
 {
   __IO uint32_t RIR;
@@ -686,20 +686,20 @@ typedef struct
   __IO uint32_t RDHR;
 } CAN_FIFOMailBox_TypeDef;
 
-/** 
-  * @brief Controller Area Network FilterRegister 
+/**
+  * @brief Controller Area Network FilterRegister
   */
-  
+
 typedef struct
 {
   __IO uint32_t FR1;
   __IO uint32_t FR2;
 } CAN_FilterRegister_TypeDef;
 
-/** 
-  * @brief Controller Area Network 
+/**
+  * @brief Controller Area Network
   */
-  
+
 typedef struct
 {
   __IO uint32_t MCR;
@@ -727,10 +727,10 @@ typedef struct
   CAN_FilterRegister_TypeDef sFilterRegister[14];
 #else
   CAN_FilterRegister_TypeDef sFilterRegister[28];
-#endif /* STM32F10X_CL */  
+#endif /* STM32F10X_CL */
 } CAN_TypeDef;
 
-/** 
+/**
   * @brief Consumer Electronics Control (CEC)
   */
 typedef struct
@@ -741,11 +741,11 @@ typedef struct
   __IO uint32_t ESR;
   __IO uint32_t CSR;
   __IO uint32_t TXD;
-  __IO uint32_t RXD;  
+  __IO uint32_t RXD;
 } CEC_TypeDef;
 
-/** 
-  * @brief CRC calculation unit 
+/**
+  * @brief CRC calculation unit
   */
 
 typedef struct
@@ -757,7 +757,7 @@ typedef struct
   __IO uint32_t CR;
 } CRC_TypeDef;
 
-/** 
+/**
   * @brief Digital to Analog Converter
   */
 
@@ -781,17 +781,17 @@ typedef struct
 #endif
 } DAC_TypeDef;
 
-/** 
+/**
   * @brief Debug MCU
   */
 
 typedef struct
 {
   __IO uint32_t IDCODE;
-  __IO uint32_t CR;	
+  __IO uint32_t CR;
 }DBGMCU_TypeDef;
 
-/** 
+/**
   * @brief DMA Controller
   */
 
@@ -809,7 +809,7 @@ typedef struct
   __IO uint32_t IFCR;
 } DMA_TypeDef;
 
-/** 
+/**
   * @brief Ethernet MAC
   */
 
@@ -880,7 +880,7 @@ typedef struct
   __IO uint32_t DMACHRBAR;
 } ETH_TypeDef;
 
-/** 
+/**
   * @brief External Interrupt/Event Controller
   */
 
@@ -894,7 +894,7 @@ typedef struct
   __IO uint32_t PR;
 } EXTI_TypeDef;
 
-/** 
+/**
   * @brief FLASH Registers
   */
 
@@ -910,19 +910,19 @@ typedef struct
   __IO uint32_t OBR;
   __IO uint32_t WRPR;
 #ifdef STM32F10X_XL
-  uint32_t RESERVED1[8]; 
+  uint32_t RESERVED1[8];
   __IO uint32_t KEYR2;
-  uint32_t RESERVED2;   
+  uint32_t RESERVED2;
   __IO uint32_t SR2;
   __IO uint32_t CR2;
-  __IO uint32_t AR2; 
-#endif /* STM32F10X_XL */  
+  __IO uint32_t AR2;
+#endif /* STM32F10X_XL */
 } FLASH_TypeDef;
 
-/** 
+/**
   * @brief Option Bytes Registers
   */
-  
+
 typedef struct
 {
   __IO uint16_t RDP;
@@ -935,66 +935,66 @@ typedef struct
   __IO uint16_t WRP3;
 } OB_TypeDef;
 
-/** 
+/**
   * @brief Flexible Static Memory Controller
   */
 
 typedef struct
 {
-  __IO uint32_t BTCR[8];   
-} FSMC_Bank1_TypeDef; 
+  __IO uint32_t BTCR[8];
+} FSMC_Bank1_TypeDef;
 
-/** 
+/**
   * @brief Flexible Static Memory Controller Bank1E
   */
-  
+
 typedef struct
 {
   __IO uint32_t BWTR[7];
 } FSMC_Bank1E_TypeDef;
 
-/** 
+/**
   * @brief Flexible Static Memory Controller Bank2
   */
-  
+
 typedef struct
 {
   __IO uint32_t PCR2;
   __IO uint32_t SR2;
   __IO uint32_t PMEM2;
   __IO uint32_t PATT2;
-  uint32_t  RESERVED0;   
-  __IO uint32_t ECCR2; 
-} FSMC_Bank2_TypeDef;  
+  uint32_t  RESERVED0;
+  __IO uint32_t ECCR2;
+} FSMC_Bank2_TypeDef;
 
-/** 
+/**
   * @brief Flexible Static Memory Controller Bank3
   */
-  
+
 typedef struct
 {
   __IO uint32_t PCR3;
   __IO uint32_t SR3;
   __IO uint32_t PMEM3;
   __IO uint32_t PATT3;
-  uint32_t  RESERVED0;   
-  __IO uint32_t ECCR3; 
-} FSMC_Bank3_TypeDef; 
+  uint32_t  RESERVED0;
+  __IO uint32_t ECCR3;
+} FSMC_Bank3_TypeDef;
 
-/** 
+/**
   * @brief Flexible Static Memory Controller Bank4
   */
-  
+
 typedef struct
 {
   __IO uint32_t PCR4;
   __IO uint32_t SR4;
   __IO uint32_t PMEM4;
   __IO uint32_t PATT4;
-  __IO uint32_t PIO4; 
-} FSMC_Bank4_TypeDef; 
+  __IO uint32_t PIO4;
+} FSMC_Bank4_TypeDef;
 
-/** 
+/**
   * @brief General Purpose I/O
   */
 
@@ -1009,7 +1009,7 @@ typedef struct
   __IO uint32_t LCKR;
 } GPIO_TypeDef;
 
-/** 
+/**
   * @brief Alternate Function I/O
   */
 
@@ -1019,9 +1019,9 @@ typedef struct
   __IO uint32_t MAPR;
   __IO uint32_t EXTICR[4];
   uint32_t RESERVED0;
-  __IO uint32_t MAPR2;  
+  __IO uint32_t MAPR2;
 } AFIO_TypeDef;
-/** 
+/**
   * @brief Inter Integrated Circuit Interface
   */
 
@@ -1047,7 +1047,7 @@ typedef struct
   uint16_t  RESERVED8;
 } I2C_TypeDef;
 
-/** 
+/**
   * @brief Independent WATCHDOG
   */
 
@@ -1059,7 +1059,7 @@ typedef struct
   __IO uint32_t SR;
 } IWDG_TypeDef;
 
-/** 
+/**
   * @brief Power Control
   */
 
@@ -1069,7 +1069,7 @@ typedef struct
   __IO uint32_t CSR;
 } PWR_TypeDef;
 
-/** 
+/**
   * @brief Reset and Clock Control
   */
 
@@ -1086,18 +1086,18 @@ typedef struct
   __IO uint32_t BDCR;
   __IO uint32_t CSR;
 
-#ifdef STM32F10X_CL  
+#ifdef STM32F10X_CL
   __IO uint32_t AHBRSTR;
   __IO uint32_t CFGR2;
-#endif /* STM32F10X_CL */ 
+#endif /* STM32F10X_CL */
 
-#if defined (STM32F10X_LD_VL) || defined (STM32F10X_MD_VL) || defined (STM32F10X_HD_VL)   
+#if defined (STM32F10X_LD_VL) || defined (STM32F10X_MD_VL) || defined (STM32F10X_HD_VL)
   uint32_t RESERVED0;
   __IO uint32_t CFGR2;
-#endif /* STM32F10X_LD_VL || STM32F10X_MD_VL || STM32F10X_HD_VL */ 
+#endif /* STM32F10X_LD_VL || STM32F10X_MD_VL || STM32F10X_HD_VL */
 } RCC_TypeDef;
 
-/** 
+/**
   * @brief Real-Time Clock
   */
 
@@ -1125,7 +1125,7 @@ typedef struct
   uint16_t  RESERVED9;
 } RTC_TypeDef;
 
-/** 
+/**
   * @brief SD host Interface
   */
 
@@ -1153,7 +1153,7 @@ typedef struct
   __IO uint32_t FIFO;
 } SDIO_TypeDef;
 
-/** 
+/**
   * @brief Serial Peripheral Interface
   */
 
@@ -1176,10 +1176,10 @@ typedef struct
   __IO uint16_t I2SCFGR;
   uint16_t  RESERVED7;
   __IO uint16_t I2SPR;
-  uint16_t  RESERVED8;  
+  uint16_t  RESERVED8;
 } SPI_TypeDef;
 
-/** 
+/**
   * @brief TIM
   */
 
@@ -1227,10 +1227,10 @@ typedef struct
   uint16_t  RESERVED19;
 } TIM_TypeDef;
 
-/** 
+/**
   * @brief Universal Synchronous Asynchronous Receiver Transmitter
   */
- 
+
 typedef struct
 {
   __IO uint16_t SR;
@@ -1249,7 +1249,7 @@ typedef struct
   uint16_t  RESERVED6;
 } USART_TypeDef;
 
-/** 
+/**
   * @brief Window WATCHDOG
   */
 
@@ -1263,7 +1263,7 @@ typedef struct
 /**
   * @}
   */
-  
+
 /** @addtogroup Peripheral_memory_map
   * @{
   */
@@ -1372,10 +1372,10 @@ typedef struct
 /**
   * @}
   */
-  
+
 /** @addtogroup Peripheral_declaration
   * @{
-  */  
+  */
 
 #define TIM2                ((TIM_TypeDef *) TIM2_BASE)
 #define TIM3                ((TIM_TypeDef *) TIM3_BASE)
@@ -1443,7 +1443,7 @@ typedef struct
 #define RCC                 ((RCC_TypeDef *) RCC_BASE)
 #define CRC                 ((CRC_TypeDef *) CRC_BASE)
 #define FLASH               ((FLASH_TypeDef *) FLASH_R_BASE)
-#define OB                  ((OB_TypeDef *) OB_BASE) 
+#define OB                  ((OB_TypeDef *) OB_BASE)
 #define ETH                 ((ETH_TypeDef *) ETH_BASE)
 #define FSMC_Bank1          ((FSMC_Bank1_TypeDef *) FSMC_Bank1_R_BASE)
 #define FSMC_Bank1E         ((FSMC_Bank1E_TypeDef *) FSMC_Bank1E_R_BASE)
@@ -1459,11 +1459,11 @@ typedef struct
 /** @addtogroup Exported_constants
   * @{
   */
-  
+
   /** @addtogroup Peripheral_Registers_Bits_Definition
   * @{
   */
-    
+
 /******************************************************************************/
 /*                         Peripheral Registers_Bits_Definition               */
 /******************************************************************************/
@@ -1791,9 +1791,9 @@ typedef struct
  #define  RCC_CFGR_PLLMULL8                  ((uint32_t)0x00180000)        /*!< PLL input clock * 8 */
  #define  RCC_CFGR_PLLMULL9                  ((uint32_t)0x001C0000)        /*!< PLL input clock * 9 */
  #define  RCC_CFGR_PLLMULL6_5                ((uint32_t)0x00340000)        /*!< PLL input clock * 6.5 */
- 
+
  #define  RCC_CFGR_OTGFSPRE                  ((uint32_t)0x00400000)        /*!< USB OTG FS prescaler */
- 
+
 /*!< MCO configuration */
  #define  RCC_CFGR_MCO                       ((uint32_t)0x0F000000)        /*!< MCO[3:0] bits (Microcontroller Clock Output) */
  #define  RCC_CFGR_MCO_0                     ((uint32_t)0x01000000)        /*!< Bit 0 */
@@ -1992,7 +1992,7 @@ typedef struct
  #define  RCC_APB1RSTR_TIM6RST                ((uint32_t)0x00000010)        /*!< Timer 6 reset */
  #define  RCC_APB1RSTR_TIM7RST                ((uint32_t)0x00000020)        /*!< Timer 7 reset */
  #define  RCC_APB1RSTR_DACRST                 ((uint32_t)0x20000000)        /*!< DAC interface reset */
- #define  RCC_APB1RSTR_CECRST                 ((uint32_t)0x40000000)        /*!< CEC interface reset */ 
+ #define  RCC_APB1RSTR_CECRST                 ((uint32_t)0x40000000)        /*!< CEC interface reset */
 #endif
 
 #if defined  (STM32F10X_HD_VL)
@@ -2000,9 +2000,9 @@ typedef struct
  #define  RCC_APB1RSTR_TIM12RST               ((uint32_t)0x00000040)        /*!< TIM12 Timer reset */
  #define  RCC_APB1RSTR_TIM13RST               ((uint32_t)0x00000080)        /*!< TIM13 Timer reset */
  #define  RCC_APB1RSTR_TIM14RST               ((uint32_t)0x00000100)        /*!< TIM14 Timer reset */
- #define  RCC_APB1RSTR_SPI3RST                ((uint32_t)0x00008000)        /*!< SPI 3 reset */ 
+ #define  RCC_APB1RSTR_SPI3RST                ((uint32_t)0x00008000)        /*!< SPI 3 reset */
  #define  RCC_APB1RSTR_UART4RST               ((uint32_t)0x00080000)        /*!< UART 4 reset */
- #define  RCC_APB1RSTR_UART5RST               ((uint32_t)0x00100000)        /*!< UART 5 reset */ 
+ #define  RCC_APB1RSTR_UART5RST               ((uint32_t)0x00100000)        /*!< UART 5 reset */
 #endif
 
 #ifdef STM32F10X_CL
@@ -2124,7 +2124,7 @@ typedef struct
  #define  RCC_APB1ENR_TIM6EN                 ((uint32_t)0x00000010)        /*!< Timer 6 clock enable */
  #define  RCC_APB1ENR_TIM7EN                 ((uint32_t)0x00000020)        /*!< Timer 7 clock enable */
  #define  RCC_APB1ENR_DACEN                  ((uint32_t)0x20000000)        /*!< DAC interface clock enable */
- #define  RCC_APB1ENR_CECEN                  ((uint32_t)0x40000000)        /*!< CEC interface clock enable */ 
+ #define  RCC_APB1ENR_CECEN                  ((uint32_t)0x40000000)        /*!< CEC interface clock enable */
 #endif
 
 #ifdef STM32F10X_HD_VL
@@ -2134,7 +2134,7 @@ typedef struct
  #define  RCC_APB1ENR_TIM14EN                ((uint32_t)0x00000100)         /*!< TIM14 Timer clock enable */
  #define  RCC_APB1ENR_SPI3EN                 ((uint32_t)0x00008000)        /*!< SPI 3 clock enable */
  #define  RCC_APB1ENR_UART4EN                ((uint32_t)0x00080000)        /*!< UART 4 clock enable */
- #define  RCC_APB1ENR_UART5EN                ((uint32_t)0x00100000)        /*!< UART 5 clock enable */ 
+ #define  RCC_APB1ENR_UART5EN                ((uint32_t)0x00100000)        /*!< UART 5 clock enable */
 #endif /* STM32F10X_HD_VL */
 
 #ifdef STM32F10X_CL
@@ -2165,7 +2165,7 @@ typedef struct
 #define  RCC_BDCR_RTCEN                      ((uint32_t)0x00008000)        /*!< RTC clock enable */
 #define  RCC_BDCR_BDRST                      ((uint32_t)0x00010000)        /*!< Backup domain software reset  */
 
-/*******************  Bit definition for RCC_CSR register  ********************/  
+/*******************  Bit definition for RCC_CSR register  ********************/
 #define  RCC_CSR_LSION                       ((uint32_t)0x00000001)        /*!< Internal Low Speed oscillator enable */
 #define  RCC_CSR_LSIRDY                      ((uint32_t)0x00000002)        /*!< Internal Low Speed oscillator Ready */
 #define  RCC_CSR_RMVF                        ((uint32_t)0x01000000)        /*!< Remove reset flag */
@@ -2297,7 +2297,7 @@ typedef struct
  #define  RCC_CFGR2_PREDIV1_DIV15            ((uint32_t)0x0000000E)        /*!< PREDIV1 input clock divided by 15 */
  #define  RCC_CFGR2_PREDIV1_DIV16            ((uint32_t)0x0000000F)        /*!< PREDIV1 input clock divided by 16 */
 #endif
- 
+
 /******************************************************************************/
 /*                                                                            */
 /*                General Purpose and Alternate Function I/O                  */
@@ -2707,7 +2707,7 @@ typedef struct
 #define AFIO_EXTICR1_EXTI1_PF                ((uint16_t)0x0050)            /*!< PF[1] pin */
 #define AFIO_EXTICR1_EXTI1_PG                ((uint16_t)0x0060)            /*!< PG[1] pin */
 
-/*!< EXTI2 configuration */  
+/*!< EXTI2 configuration */
 #define AFIO_EXTICR1_EXTI2_PA                ((uint16_t)0x0000)            /*!< PA[2] pin */
 #define AFIO_EXTICR1_EXTI2_PB                ((uint16_t)0x0100)            /*!< PB[2] pin */
 #define AFIO_EXTICR1_EXTI2_PC                ((uint16_t)0x0200)            /*!< PC[2] pin */
@@ -2749,7 +2749,7 @@ typedef struct
 #define AFIO_EXTICR2_EXTI5_PF                ((uint16_t)0x0050)            /*!< PF[5] pin */
 #define AFIO_EXTICR2_EXTI5_PG                ((uint16_t)0x0060)            /*!< PG[5] pin */
 
-/*!< EXTI6 configuration */  
+/*!< EXTI6 configuration */
 #define AFIO_EXTICR2_EXTI6_PA                ((uint16_t)0x0000)            /*!< PA[6] pin */
 #define AFIO_EXTICR2_EXTI6_PB                ((uint16_t)0x0100)            /*!< PB[6] pin */
 #define AFIO_EXTICR2_EXTI6_PC                ((uint16_t)0x0200)            /*!< PC[6] pin */
@@ -2791,7 +2791,7 @@ typedef struct
 #define AFIO_EXTICR3_EXTI9_PF                ((uint16_t)0x0050)            /*!< PF[9] pin */
 #define AFIO_EXTICR3_EXTI9_PG                ((uint16_t)0x0060)            /*!< PG[9] pin */
 
-/*!< EXTI10 configuration */  
+/*!< EXTI10 configuration */
 #define AFIO_EXTICR3_EXTI10_PA               ((uint16_t)0x0000)            /*!< PA[10] pin */
 #define AFIO_EXTICR3_EXTI10_PB               ((uint16_t)0x0100)            /*!< PB[10] pin */
 #define AFIO_EXTICR3_EXTI10_PC               ((uint16_t)0x0200)            /*!< PC[10] pin */
@@ -2833,7 +2833,7 @@ typedef struct
 #define AFIO_EXTICR4_EXTI13_PF               ((uint16_t)0x0050)            /*!< PF[13] pin */
 #define AFIO_EXTICR4_EXTI13_PG               ((uint16_t)0x0060)            /*!< PG[13] pin */
 
-/*!< EXTI14 configuration */  
+/*!< EXTI14 configuration */
 #define AFIO_EXTICR4_EXTI14_PA               ((uint16_t)0x0000)            /*!< PA[14] pin */
 #define AFIO_EXTICR4_EXTI14_PB               ((uint16_t)0x0100)            /*!< PB[14] pin */
 #define AFIO_EXTICR4_EXTI14_PC               ((uint16_t)0x0200)            /*!< PC[14] pin */
@@ -2869,7 +2869,7 @@ typedef struct
 #define AFIO_MAPR2_MISC_REMAP                ((uint32_t)0x00002000)        /*!< Miscellaneous remapping */
 #endif
 
-#ifdef STM32F10X_XL 
+#ifdef STM32F10X_XL
 /******************  Bit definition for AFIO_MAPR2 register  ******************/
 #define AFIO_MAPR2_TIM9_REMAP                ((uint32_t)0x00000020)        /*!< TIM9 remapping */
 #define AFIO_MAPR2_TIM10_REMAP               ((uint32_t)0x00000040)        /*!< TIM10 remapping */
@@ -3737,7 +3737,7 @@ typedef struct
 #define  ADC_CR1_JAWDEN                      ((uint32_t)0x00400000)        /*!< Analog watchdog enable on injected channels */
 #define  ADC_CR1_AWDEN                       ((uint32_t)0x00800000)        /*!< Analog watchdog enable on regular channels */
 
-  
+
 /*******************  Bit definition for ADC_CR2 register  ********************/
 #define  ADC_CR2_ADON                        ((uint32_t)0x00000001)        /*!< A/D Converter ON / OFF */
 #define  ADC_CR2_CONT                        ((uint32_t)0x00000002)        /*!< Continuous Conversion */
@@ -3995,7 +3995,7 @@ typedef struct
 #define  ADC_SQR3_SQ6_4                      ((uint32_t)0x20000000)        /*!< Bit 4 */
 
 /*******************  Bit definition for ADC_JSQR register  *******************/
-#define  ADC_JSQR_JSQ1                       ((uint32_t)0x0000001F)        /*!< JSQ1[4:0] bits (1st conversion in injected sequence) */  
+#define  ADC_JSQR_JSQ1                       ((uint32_t)0x0000001F)        /*!< JSQ1[4:0] bits (1st conversion in injected sequence) */
 #define  ADC_JSQR_JSQ1_0                     ((uint32_t)0x00000001)        /*!< Bit 0 */
 #define  ADC_JSQR_JSQ1_1                     ((uint32_t)0x00000002)        /*!< Bit 1 */
 #define  ADC_JSQR_JSQ1_2                     ((uint32_t)0x00000004)        /*!< Bit 2 */
@@ -5786,7 +5786,7 @@ typedef struct
 
 #define  USB_DADDR_EF                        ((uint8_t)0x80)               /*!< Enable Function */
 
-/******************  Bit definition for USB_BTABLE register  ******************/    
+/******************  Bit definition for USB_BTABLE register  ******************/
 #define  USB_BTABLE_BTABLE                   ((uint16_t)0xFFF8)            /*!< Buffer Table */
 
 /*!< Buffer descriptor table */
@@ -6370,7 +6370,7 @@ typedef struct
 #define  CAN_TI2R_EXID                       ((uint32_t)0x001FFFF8)        /*!< Extended identifier */
 #define  CAN_TI2R_STID                       ((uint32_t)0xFFE00000)        /*!< Standard Identifier or Extended Identifier */
 
-/*******************  Bit definition for CAN_TDT2R register  ******************/  
+/*******************  Bit definition for CAN_TDT2R register  ******************/
 #define  CAN_TDT2R_DLC                       ((uint32_t)0x0000000F)        /*!< Data Length Code */
 #define  CAN_TDT2R_TGT                       ((uint32_t)0x00000100)        /*!< Transmit Global Time */
 #define  CAN_TDT2R_TIME                      ((uint32_t)0xFFFF0000)        /*!< Message Time Stamp */
@@ -7883,10 +7883,10 @@ typedef struct
   #define ETH_MACCR_IFG_88Bit     ((uint32_t)0x00020000)  /* Minimum IFG between frames during transmission is 88Bit */
   #define ETH_MACCR_IFG_80Bit     ((uint32_t)0x00040000)  /* Minimum IFG between frames during transmission is 80Bit */
   #define ETH_MACCR_IFG_72Bit     ((uint32_t)0x00060000)  /* Minimum IFG between frames during transmission is 72Bit */
-  #define ETH_MACCR_IFG_64Bit     ((uint32_t)0x00080000)  /* Minimum IFG between frames during transmission is 64Bit */        
+  #define ETH_MACCR_IFG_64Bit     ((uint32_t)0x00080000)  /* Minimum IFG between frames during transmission is 64Bit */
   #define ETH_MACCR_IFG_56Bit     ((uint32_t)0x000A0000)  /* Minimum IFG between frames during transmission is 56Bit */
   #define ETH_MACCR_IFG_48Bit     ((uint32_t)0x000C0000)  /* Minimum IFG between frames during transmission is 48Bit */
-  #define ETH_MACCR_IFG_40Bit     ((uint32_t)0x000E0000)  /* Minimum IFG between frames during transmission is 40Bit */              
+  #define ETH_MACCR_IFG_40Bit     ((uint32_t)0x000E0000)  /* Minimum IFG between frames during transmission is 40Bit */
 #define ETH_MACCR_CSD     ((uint32_t)0x00010000)  /* Carrier sense disable (during transmission) */
 #define ETH_MACCR_FES     ((uint32_t)0x00004000)  /* Fast ethernet speed */
 #define ETH_MACCR_ROD     ((uint32_t)0x00002000)  /* Receive own disable */
@@ -7900,24 +7900,24 @@ typedef struct
   #define ETH_MACCR_BL_10    ((uint32_t)0x00000000)  /* k = min (n, 10) */
   #define ETH_MACCR_BL_8     ((uint32_t)0x00000020)  /* k = min (n, 8) */
   #define ETH_MACCR_BL_4     ((uint32_t)0x00000040)  /* k = min (n, 4) */
-  #define ETH_MACCR_BL_1     ((uint32_t)0x00000060)  /* k = min (n, 1) */ 
+  #define ETH_MACCR_BL_1     ((uint32_t)0x00000060)  /* k = min (n, 1) */
 #define ETH_MACCR_DC      ((uint32_t)0x00000010)  /* Defferal check */
 #define ETH_MACCR_TE      ((uint32_t)0x00000008)  /* Transmitter enable */
 #define ETH_MACCR_RE      ((uint32_t)0x00000004)  /* Receiver enable */
 
 /* Bit definition for Ethernet MAC Frame Filter Register */
-#define ETH_MACFFR_RA     ((uint32_t)0x80000000)  /* Receive all */ 
-#define ETH_MACFFR_HPF    ((uint32_t)0x00000400)  /* Hash or perfect filter */ 
-#define ETH_MACFFR_SAF    ((uint32_t)0x00000200)  /* Source address filter enable */ 
-#define ETH_MACFFR_SAIF   ((uint32_t)0x00000100)  /* SA inverse filtering */ 
+#define ETH_MACFFR_RA     ((uint32_t)0x80000000)  /* Receive all */
+#define ETH_MACFFR_HPF    ((uint32_t)0x00000400)  /* Hash or perfect filter */
+#define ETH_MACFFR_SAF    ((uint32_t)0x00000200)  /* Source address filter enable */
+#define ETH_MACFFR_SAIF   ((uint32_t)0x00000100)  /* SA inverse filtering */
 #define ETH_MACFFR_PCF    ((uint32_t)0x000000C0)  /* Pass control frames: 3 cases */
   #define ETH_MACFFR_PCF_BlockAll                ((uint32_t)0x00000040)  /* MAC filters all control frames from reaching the application */
   #define ETH_MACFFR_PCF_ForwardAll              ((uint32_t)0x00000080)  /* MAC forwards all control frames to application even if they fail the Address Filter */
-  #define ETH_MACFFR_PCF_ForwardPassedAddrFilter ((uint32_t)0x000000C0)  /* MAC forwards control frames that pass the Address Filter. */ 
-#define ETH_MACFFR_BFD    ((uint32_t)0x00000020)  /* Broadcast frame disable */ 
-#define ETH_MACFFR_PAM 	  ((uint32_t)0x00000010)  /* Pass all mutlicast */ 
-#define ETH_MACFFR_DAIF   ((uint32_t)0x00000008)  /* DA Inverse filtering */ 
-#define ETH_MACFFR_HM     ((uint32_t)0x00000004)  /* Hash multicast */ 
+  #define ETH_MACFFR_PCF_ForwardPassedAddrFilter ((uint32_t)0x000000C0)  /* MAC forwards control frames that pass the Address Filter. */
+#define ETH_MACFFR_BFD    ((uint32_t)0x00000020)  /* Broadcast frame disable */
+#define ETH_MACFFR_PAM 	  ((uint32_t)0x00000010)  /* Pass all mutlicast */
+#define ETH_MACFFR_DAIF   ((uint32_t)0x00000008)  /* DA Inverse filtering */
+#define ETH_MACFFR_HM     ((uint32_t)0x00000004)  /* Hash multicast */
 #define ETH_MACFFR_HU     ((uint32_t)0x00000002)  /* Hash unicast */
 #define ETH_MACFFR_PM     ((uint32_t)0x00000001)  /* Promiscuous mode */
 
@@ -7928,15 +7928,15 @@ typedef struct
 #define ETH_MACHTLR_HTL   ((uint32_t)0xFFFFFFFF)  /* Hash table low */
 
 /* Bit definition for Ethernet MAC MII Address Register */
-#define ETH_MACMIIAR_PA   ((uint32_t)0x0000F800)  /* Physical layer address */ 
-#define ETH_MACMIIAR_MR   ((uint32_t)0x000007C0)  /* MII register in the selected PHY */ 
-#define ETH_MACMIIAR_CR   ((uint32_t)0x0000001C)  /* CR clock range: 6 cases */ 
+#define ETH_MACMIIAR_PA   ((uint32_t)0x0000F800)  /* Physical layer address */
+#define ETH_MACMIIAR_MR   ((uint32_t)0x000007C0)  /* MII register in the selected PHY */
+#define ETH_MACMIIAR_CR   ((uint32_t)0x0000001C)  /* CR clock range: 6 cases */
   #define ETH_MACMIIAR_CR_Div42   ((uint32_t)0x00000000)  /* HCLK:60-72 MHz; MDC clock= HCLK/42 */
   #define ETH_MACMIIAR_CR_Div16   ((uint32_t)0x00000008)  /* HCLK:20-35 MHz; MDC clock= HCLK/16 */
   #define ETH_MACMIIAR_CR_Div26   ((uint32_t)0x0000000C)  /* HCLK:35-60 MHz; MDC clock= HCLK/26 */
-#define ETH_MACMIIAR_MW   ((uint32_t)0x00000002)  /* MII write */ 
-#define ETH_MACMIIAR_MB   ((uint32_t)0x00000001)  /* MII busy */ 
-  
+#define ETH_MACMIIAR_MW   ((uint32_t)0x00000002)  /* MII write */
+#define ETH_MACMIIAR_MB   ((uint32_t)0x00000001)  /* MII busy */
+
 /* Bit definition for Ethernet MAC MII Data Register */
 #define ETH_MACMIIDR_MD   ((uint32_t)0x0000FFFF)  /* MII data: read/write data from/to PHY */
 
@@ -7947,7 +7947,7 @@ typedef struct
   #define ETH_MACFCR_PLT_Minus4   ((uint32_t)0x00000000)  /* Pause time minus 4 slot times */
   #define ETH_MACFCR_PLT_Minus28  ((uint32_t)0x00000010)  /* Pause time minus 28 slot times */
   #define ETH_MACFCR_PLT_Minus144 ((uint32_t)0x00000020)  /* Pause time minus 144 slot times */
-  #define ETH_MACFCR_PLT_Minus256 ((uint32_t)0x00000030)  /* Pause time minus 256 slot times */      
+  #define ETH_MACFCR_PLT_Minus256 ((uint32_t)0x00000030)  /* Pause time minus 256 slot times */
 #define ETH_MACFCR_UPFD   ((uint32_t)0x00000008)  /* Unicast pause frame detect */
 #define ETH_MACFCR_RFCE   ((uint32_t)0x00000004)  /* Receive flow control enable */
 #define ETH_MACFCR_TFCE   ((uint32_t)0x00000002)  /* Transmit flow control enable */
@@ -7957,7 +7957,7 @@ typedef struct
 #define ETH_MACVLANTR_VLANTC ((uint32_t)0x00010000)  /* 12-bit VLAN tag comparison */
 #define ETH_MACVLANTR_VLANTI ((uint32_t)0x0000FFFF)  /* VLAN tag identifier (for receive frames) */
 
-/* Bit definition for Ethernet MAC Remote Wake-UpFrame Filter Register */ 
+/* Bit definition for Ethernet MAC Remote Wake-UpFrame Filter Register */
 #define ETH_MACRWUFFR_D   ((uint32_t)0xFFFFFFFF)  /* Wake-up frame filter register data */
 /* Eight sequential Writes to this address (offset 0x28) will write all Wake-UpFrame Filter Registers.
    Eight sequential Reads from this address (offset 0x28) will read all Wake-UpFrame Filter Registers. */
@@ -7965,13 +7965,13 @@ typedef struct
    Wake-UpFrame Filter Reg1 : Filter 1 Byte Mask
    Wake-UpFrame Filter Reg2 : Filter 2 Byte Mask
    Wake-UpFrame Filter Reg3 : Filter 3 Byte Mask
-   Wake-UpFrame Filter Reg4 : RSVD - Filter3 Command - RSVD - Filter2 Command - 
+   Wake-UpFrame Filter Reg4 : RSVD - Filter3 Command - RSVD - Filter2 Command -
                               RSVD - Filter1 Command - RSVD - Filter0 Command
    Wake-UpFrame Filter Re5 : Filter3 Offset - Filter2 Offset - Filter1 Offset - Filter0 Offset
    Wake-UpFrame Filter Re6 : Filter1 CRC16 - Filter0 CRC16
    Wake-UpFrame Filter Re7 : Filter3 CRC16 - Filter2 CRC16 */
 
-/* Bit definition for Ethernet MAC PMT Control and Status Register */ 
+/* Bit definition for Ethernet MAC PMT Control and Status Register */
 #define ETH_MACPMTCSR_WFFRPR ((uint32_t)0x80000000)  /* Wake-Up Frame Filter Register Pointer Reset */
 #define ETH_MACPMTCSR_GU     ((uint32_t)0x00000200)  /* Global Unicast */
 #define ETH_MACPMTCSR_WFR    ((uint32_t)0x00000040)  /* Wake-Up Frame Received */
@@ -8006,7 +8006,7 @@ typedef struct
   #define ETH_MACA1HR_MBC_LBits31_24   ((uint32_t)0x08000000)  /* Mask MAC Address low reg bits [31:24] */
   #define ETH_MACA1HR_MBC_LBits23_16   ((uint32_t)0x04000000)  /* Mask MAC Address low reg bits [23:16] */
   #define ETH_MACA1HR_MBC_LBits15_8    ((uint32_t)0x02000000)  /* Mask MAC Address low reg bits [15:8] */
-  #define ETH_MACA1HR_MBC_LBits7_0     ((uint32_t)0x01000000)  /* Mask MAC Address low reg bits [7:0] */ 
+  #define ETH_MACA1HR_MBC_LBits7_0     ((uint32_t)0x01000000)  /* Mask MAC Address low reg bits [7:0] */
 #define ETH_MACA1HR_MACA1H   ((uint32_t)0x0000FFFF)  /* MAC address1 high */
 
 /* Bit definition for Ethernet MAC Address1 Low Register */
@@ -8142,26 +8142,26 @@ typedef struct
   #define ETH_DMABMR_RDP_4Beat    ((uint32_t)0x00080000)  /* maximum number of beats to be transferred in one RxDMA transaction is 4 */
   #define ETH_DMABMR_RDP_8Beat    ((uint32_t)0x00100000)  /* maximum number of beats to be transferred in one RxDMA transaction is 8 */
   #define ETH_DMABMR_RDP_16Beat   ((uint32_t)0x00200000)  /* maximum number of beats to be transferred in one RxDMA transaction is 16 */
-  #define ETH_DMABMR_RDP_32Beat   ((uint32_t)0x00400000)  /* maximum number of beats to be transferred in one RxDMA transaction is 32 */                
+  #define ETH_DMABMR_RDP_32Beat   ((uint32_t)0x00400000)  /* maximum number of beats to be transferred in one RxDMA transaction is 32 */
   #define ETH_DMABMR_RDP_4xPBL_4Beat   ((uint32_t)0x01020000)  /* maximum number of beats to be transferred in one RxDMA transaction is 4 */
   #define ETH_DMABMR_RDP_4xPBL_8Beat   ((uint32_t)0x01040000)  /* maximum number of beats to be transferred in one RxDMA transaction is 8 */
   #define ETH_DMABMR_RDP_4xPBL_16Beat  ((uint32_t)0x01080000)  /* maximum number of beats to be transferred in one RxDMA transaction is 16 */
   #define ETH_DMABMR_RDP_4xPBL_32Beat  ((uint32_t)0x01100000)  /* maximum number of beats to be transferred in one RxDMA transaction is 32 */
   #define ETH_DMABMR_RDP_4xPBL_64Beat  ((uint32_t)0x01200000)  /* maximum number of beats to be transferred in one RxDMA transaction is 64 */
-  #define ETH_DMABMR_RDP_4xPBL_128Beat ((uint32_t)0x01400000)  /* maximum number of beats to be transferred in one RxDMA transaction is 128 */  
+  #define ETH_DMABMR_RDP_4xPBL_128Beat ((uint32_t)0x01400000)  /* maximum number of beats to be transferred in one RxDMA transaction is 128 */
 #define ETH_DMABMR_FB        ((uint32_t)0x00010000)  /* Fixed Burst */
 #define ETH_DMABMR_RTPR      ((uint32_t)0x0000C000)  /* Rx Tx priority ratio */
   #define ETH_DMABMR_RTPR_1_1     ((uint32_t)0x00000000)  /* Rx Tx priority ratio */
   #define ETH_DMABMR_RTPR_2_1     ((uint32_t)0x00004000)  /* Rx Tx priority ratio */
   #define ETH_DMABMR_RTPR_3_1     ((uint32_t)0x00008000)  /* Rx Tx priority ratio */
-  #define ETH_DMABMR_RTPR_4_1     ((uint32_t)0x0000C000)  /* Rx Tx priority ratio */  
+  #define ETH_DMABMR_RTPR_4_1     ((uint32_t)0x0000C000)  /* Rx Tx priority ratio */
 #define ETH_DMABMR_PBL    ((uint32_t)0x00003F00)  /* Programmable burst length */
   #define ETH_DMABMR_PBL_1Beat    ((uint32_t)0x00000100)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 1 */
   #define ETH_DMABMR_PBL_2Beat    ((uint32_t)0x00000200)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 2 */
   #define ETH_DMABMR_PBL_4Beat    ((uint32_t)0x00000400)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
   #define ETH_DMABMR_PBL_8Beat    ((uint32_t)0x00000800)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
   #define ETH_DMABMR_PBL_16Beat   ((uint32_t)0x00001000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
-  #define ETH_DMABMR_PBL_32Beat   ((uint32_t)0x00002000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */                
+  #define ETH_DMABMR_PBL_32Beat   ((uint32_t)0x00002000)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
   #define ETH_DMABMR_PBL_4xPBL_4Beat   ((uint32_t)0x01000100)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
   #define ETH_DMABMR_PBL_4xPBL_8Beat   ((uint32_t)0x01000200)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
   #define ETH_DMABMR_PBL_4xPBL_16Beat  ((uint32_t)0x01000400)  /* maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
@@ -8206,7 +8206,7 @@ typedef struct
   #define ETH_DMASR_RPS_Waiting         ((uint32_t)0x00060000)  /* Running - waiting for packet */
   #define ETH_DMASR_RPS_Suspended       ((uint32_t)0x00080000)  /* Suspended - Rx Descriptor unavailable */
   #define ETH_DMASR_RPS_Closing         ((uint32_t)0x000A0000)  /* Running - closing descriptor */
-  #define ETH_DMASR_RPS_Queuing         ((uint32_t)0x000E0000)  /* Running - queuing the recieve frame into host memory */
+  #define ETH_DMASR_RPS_Queuing         ((uint32_t)0x000E0000)  /* Running - queuing the receive frame into host memory */
 #define ETH_DMASR_NIS        ((uint32_t)0x00010000)  /* Normal interrupt summary */
 #define ETH_DMASR_AIS        ((uint32_t)0x00008000)  /* Abnormal interrupt summary */
 #define ETH_DMASR_ERS        ((uint32_t)0x00004000)  /* Early receive status */
@@ -8291,7 +8291,7 @@ typedef struct
 
  /**
   * @}
-  */ 
+  */
 
 #ifdef USE_STDPERIPH_DRIVER
   #include "stm32f10x_conf.h"

--- a/lib/STM32F30x_StdPeriph_Driver/src/stm32f30x_can.c
+++ b/lib/STM32F30x_StdPeriph_Driver/src/stm32f30x_can.c
@@ -4,49 +4,49 @@
   * @author  MCD Application Team
   * @version V1.1.1
   * @date    04-April-2014
-  * @brief   This file provides firmware functions to manage the following 
-  *          functionalities of the Controller area network (CAN) peripheral:           
-  *           + Initialization and Configuration 
-  *           + CAN Frames Transmission 
-  *           + CAN Frames Reception    
-  *           + Operation modes switch  
-  *           + Error management          
-  *           + Interrupts and flags        
-  *         
+  * @brief   This file provides firmware functions to manage the following
+  *          functionalities of the Controller area network (CAN) peripheral:
+  *           + Initialization and Configuration
+  *           + CAN Frames Transmission
+  *           + CAN Frames Reception
+  *           + Operation modes switch
+  *           + Error management
+  *           + Interrupts and flags
+  *
   @verbatim
-                               
- ===============================================================================      
+
+ ===============================================================================
                       ##### How to use this driver #####
- ===============================================================================                
+ ===============================================================================
     [..]
-    (#) Enable the CAN controller interface clock using 
-        RCC_APB1PeriphClockCmd(RCC_APB1Periph_CAN1, ENABLE);      
+    (#) Enable the CAN controller interface clock using
+        RCC_APB1PeriphClockCmd(RCC_APB1Periph_CAN1, ENABLE);
     (#) CAN pins configuration:
         (++) Enable the clock for the CAN GPIOs using the following function:
-             RCC_AHBPeriphClockCmd(RCC_AHBPeriph_GPIOx, ENABLE);   
-        (++) Connect the involved CAN pins to AF9 using the following function 
-             GPIO_PinAFConfig(GPIOx, GPIO_PinSourcex, GPIO_AF_CANx); 
+             RCC_AHBPeriphClockCmd(RCC_AHBPeriph_GPIOx, ENABLE);
+        (++) Connect the involved CAN pins to AF9 using the following function
+             GPIO_PinAFConfig(GPIOx, GPIO_PinSourcex, GPIO_AF_CANx);
         (++) Configure these CAN pins in alternate function mode by calling
              the function  GPIO_Init();
-    (#) Initialise and configure the CAN using CAN_Init() and 
-        CAN_FilterInit() functions.   
+    (#) Initialise and configure the CAN using CAN_Init() and
+        CAN_FilterInit() functions.
     (#) Transmit the desired CAN frame using CAN_Transmit() function.
     (#) Check the transmission of a CAN frame using CAN_TransmitStatus() function.
-    (#) Cancel the transmission of a CAN frame using CAN_CancelTransmit() function.  
-    (#) Receive a CAN frame using CAN_Recieve() function.
+    (#) Cancel the transmission of a CAN frame using CAN_CancelTransmit() function.
+    (#) Receive a CAN frame using CAN_Receive() function.
     (#) Release the receive FIFOs using CAN_FIFORelease() function.
-    (#) Return the number of pending received frames using CAN_MessagePending() function.            
+    (#) Return the number of pending received frames using CAN_MessagePending() function.
     (#) To control CAN events you can use one of the following two methods:
-        (++) Check on CAN flags using the CAN_GetFlagStatus() function.  
-        (++) Use CAN interrupts through the function CAN_ITConfig() at initialization 
-             phase and CAN_GetITStatus() function into interrupt routines to check 
+        (++) Check on CAN flags using the CAN_GetFlagStatus() function.
+        (++) Use CAN interrupts through the function CAN_ITConfig() at initialization
+             phase and CAN_GetITStatus() function into interrupt routines to check
              if the event has occurred or not.
              After checking on a flag you should clear it using CAN_ClearFlag()
-             function. And after checking on an interrupt event you should clear it 
-             using CAN_ClearITPendingBit() function.            
-                 
+             function. And after checking on an interrupt event you should clear it
+             using CAN_ClearITPendingBit() function.
+
   @endverbatim
-  *       
+  *
   ******************************************************************************
   * @attention
   *
@@ -58,8 +58,8 @@
   *
   *        http://www.st.com/software_license_agreement_liberty_v2
   *
-  * Unless required by applicable law or agreed to in writing, software 
-  * distributed under the License is distributed on an "AS IS" BASIS, 
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   * See the License for the specific language governing permissions and
   * limitations under the License.
@@ -75,10 +75,10 @@
   * @{
   */
 
-/** @defgroup CAN 
+/** @defgroup CAN
   * @brief CAN driver modules
   * @{
-  */ 
+  */
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 
@@ -97,20 +97,20 @@
 #define SLAK_TIMEOUT      ((uint32_t)0x00FFFFFF)
 
 /* Flags in TSR register */
-#define CAN_FLAGS_TSR     ((uint32_t)0x08000000) 
+#define CAN_FLAGS_TSR     ((uint32_t)0x08000000)
 /* Flags in RF1R register */
-#define CAN_FLAGS_RF1R    ((uint32_t)0x04000000) 
+#define CAN_FLAGS_RF1R    ((uint32_t)0x04000000)
 /* Flags in RF0R register */
-#define CAN_FLAGS_RF0R    ((uint32_t)0x02000000) 
+#define CAN_FLAGS_RF0R    ((uint32_t)0x02000000)
 /* Flags in MSR register */
-#define CAN_FLAGS_MSR     ((uint32_t)0x01000000) 
+#define CAN_FLAGS_MSR     ((uint32_t)0x01000000)
 /* Flags in ESR register */
-#define CAN_FLAGS_ESR     ((uint32_t)0x00F00000) 
+#define CAN_FLAGS_ESR     ((uint32_t)0x00F00000)
 
 /* Mailboxes definition */
 #define CAN_TXMAILBOX_0   ((uint8_t)0x00)
 #define CAN_TXMAILBOX_1   ((uint8_t)0x01)
-#define CAN_TXMAILBOX_2   ((uint8_t)0x02) 
+#define CAN_TXMAILBOX_2   ((uint8_t)0x02)
 
 #define CAN_MODE_MASK     ((uint32_t) 0x00000003)
 
@@ -125,25 +125,25 @@ static ITStatus CheckITStatus(uint32_t CAN_Reg, uint32_t It_Bit);
   */
 
 /** @defgroup CAN_Group1 Initialization and Configuration functions
- *  @brief    Initialization and Configuration functions 
+ *  @brief    Initialization and Configuration functions
  *
-@verbatim    
+@verbatim
  ===============================================================================
               ##### Initialization and Configuration functions #####
- ===============================================================================  
-    [..] This section provides functions allowing to: 
-         (+) Initialize the CAN peripherals : Prescaler, operating mode, the maximum 
-             number of time quanta to perform resynchronization, the number of time 
-             quanta in Bit Segment 1 and 2 and many other modes. 
-         (+) Configure the CAN reception filter.                                      
+ ===============================================================================
+    [..] This section provides functions allowing to:
+         (+) Initialize the CAN peripherals : Prescaler, operating mode, the maximum
+             number of time quanta to perform resynchronization, the number of time
+             quanta in Bit Segment 1 and 2 and many other modes.
+         (+) Configure the CAN reception filter.
          (+) Select the start bank filter for slave CAN.
          (+) Enable or disable the Debug Freeze mode for CAN.
          (+) Enable or disable the CAN Time Trigger Operation communication mode.
-   
+
 @endverbatim
   * @{
   */
-  
+
 /**
   * @brief  Deinitializes the CAN peripheral registers to their default reset values.
   * @param  CANx: where x can be 1 to select the CAN1 peripheral.
@@ -153,7 +153,7 @@ void CAN_DeInit(CAN_TypeDef* CANx)
 {
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
- 
+
   /* Enable CAN1 reset state */
   RCC_APB1PeriphResetCmd(RCC_APB1Periph_CAN1, ENABLE);
   /* Release CAN1 from reset state */
@@ -166,7 +166,7 @@ void CAN_DeInit(CAN_TypeDef* CANx)
   * @param  CANx: where x can be 1 to select the CAN1 peripheral.
   * @param  CAN_InitStruct: pointer to a CAN_InitTypeDef structure that contains
   *         the configuration information for the CAN peripheral.
-  * @retval Constant indicates initialization succeed which will be 
+  * @retval Constant indicates initialization succeed which will be
   *         CAN_InitStatus_Failed or CAN_InitStatus_Success.
   */
 uint8_t CAN_Init(CAN_TypeDef* CANx, CAN_InitTypeDef* CAN_InitStruct)
@@ -204,7 +204,7 @@ uint8_t CAN_Init(CAN_TypeDef* CANx, CAN_InitTypeDef* CAN_InitStruct)
   {
     InitStatus = CAN_InitStatus_Failed;
   }
-  else 
+  else
   {
     /* Set the time triggered communication mode */
     if (CAN_InitStruct->CAN_TTCM == ENABLE)
@@ -332,13 +332,13 @@ void CAN_FilterInit(CAN_FilterInitTypeDef* CAN_FilterInitStruct)
 
     /* First 16-bit identifier and First 16-bit mask */
     /* Or First 16-bit identifier and Second 16-bit identifier */
-    CAN1->sFilterRegister[CAN_FilterInitStruct->CAN_FilterNumber].FR1 = 
+    CAN1->sFilterRegister[CAN_FilterInitStruct->CAN_FilterNumber].FR1 =
        ((0x0000FFFF & (uint32_t)CAN_FilterInitStruct->CAN_FilterMaskIdLow) << 16) |
         (0x0000FFFF & (uint32_t)CAN_FilterInitStruct->CAN_FilterIdLow);
 
     /* Second 16-bit identifier and Second 16-bit mask */
     /* Or Third 16-bit identifier and Fourth 16-bit identifier */
-    CAN1->sFilterRegister[CAN_FilterInitStruct->CAN_FilterNumber].FR2 = 
+    CAN1->sFilterRegister[CAN_FilterInitStruct->CAN_FilterNumber].FR2 =
        ((0x0000FFFF & (uint32_t)CAN_FilterInitStruct->CAN_FilterMaskIdHigh) << 16) |
         (0x0000FFFF & (uint32_t)CAN_FilterInitStruct->CAN_FilterIdHigh);
   }
@@ -348,11 +348,11 @@ void CAN_FilterInit(CAN_FilterInitTypeDef* CAN_FilterInitStruct)
     /* 32-bit scale for the filter */
     CAN1->FS1R |= filter_number_bit_pos;
     /* 32-bit identifier or First 32-bit identifier */
-    CAN1->sFilterRegister[CAN_FilterInitStruct->CAN_FilterNumber].FR1 = 
+    CAN1->sFilterRegister[CAN_FilterInitStruct->CAN_FilterNumber].FR1 =
        ((0x0000FFFF & (uint32_t)CAN_FilterInitStruct->CAN_FilterIdHigh) << 16) |
         (0x0000FFFF & (uint32_t)CAN_FilterInitStruct->CAN_FilterIdLow);
     /* 32-bit mask or Second 32-bit identifier */
-    CAN1->sFilterRegister[CAN_FilterInitStruct->CAN_FilterNumber].FR2 = 
+    CAN1->sFilterRegister[CAN_FilterInitStruct->CAN_FilterNumber].FR2 =
        ((0x0000FFFF & (uint32_t)CAN_FilterInitStruct->CAN_FilterMaskIdHigh) << 16) |
         (0x0000FFFF & (uint32_t)CAN_FilterInitStruct->CAN_FilterMaskIdLow);
   }
@@ -381,7 +381,7 @@ void CAN_FilterInit(CAN_FilterInitTypeDef* CAN_FilterInitStruct)
     /* FIFO 1 assignation for the filter */
     CAN1->FFA1R |= (uint32_t)filter_number_bit_pos;
   }
-  
+
   /* Filter activation */
   if (CAN_FilterInitStruct->CAN_FilterActivation == ENABLE)
   {
@@ -400,37 +400,37 @@ void CAN_FilterInit(CAN_FilterInitTypeDef* CAN_FilterInitStruct)
 void CAN_StructInit(CAN_InitTypeDef* CAN_InitStruct)
 {
   /* Reset CAN init structure parameters values */
-  
+
   /* Initialize the time triggered communication mode */
   CAN_InitStruct->CAN_TTCM = DISABLE;
-  
+
   /* Initialize the automatic bus-off management */
   CAN_InitStruct->CAN_ABOM = DISABLE;
-  
+
   /* Initialize the automatic wake-up mode */
   CAN_InitStruct->CAN_AWUM = DISABLE;
-  
+
   /* Initialize the no automatic retransmission */
   CAN_InitStruct->CAN_NART = DISABLE;
-  
+
   /* Initialize the receive FIFO locked mode */
   CAN_InitStruct->CAN_RFLM = DISABLE;
-  
+
   /* Initialize the transmit FIFO priority */
   CAN_InitStruct->CAN_TXFP = DISABLE;
-  
+
   /* Initialize the CAN_Mode member */
   CAN_InitStruct->CAN_Mode = CAN_Mode_Normal;
-  
+
   /* Initialize the CAN_SJW member */
   CAN_InitStruct->CAN_SJW = CAN_SJW_1tq;
-  
+
   /* Initialize the CAN_BS1 member */
   CAN_InitStruct->CAN_BS1 = CAN_BS1_4tq;
-  
+
   /* Initialize the CAN_BS2 member */
   CAN_InitStruct->CAN_BS2 = CAN_BS2_3tq;
-  
+
   /* Initialize the CAN_Prescaler member */
   CAN_InitStruct->CAN_Prescaler = 1;
 }
@@ -440,18 +440,18 @@ void CAN_StructInit(CAN_InitTypeDef* CAN_InitStruct)
   * @param  CAN_BankNumber: Select the start slave bank filter from 1..27.
   * @retval None
   */
-void CAN_SlaveStartBank(uint8_t CAN_BankNumber) 
+void CAN_SlaveStartBank(uint8_t CAN_BankNumber)
 {
   /* Check the parameters */
   assert_param(IS_CAN_BANKNUMBER(CAN_BankNumber));
-  
+
   /* Enter Initialisation mode for the filter */
   CAN1->FMR |= FMR_FINIT;
-  
+
   /* Select the start slave bank */
   CAN1->FMR &= (uint32_t)0xFFFFC0F1 ;
   CAN1->FMR |= (uint32_t)(CAN_BankNumber)<<8;
-  
+
   /* Leave Initialisation mode for the filter */
   CAN1->FMR &= ~FMR_FINIT;
 }
@@ -459,9 +459,9 @@ void CAN_SlaveStartBank(uint8_t CAN_BankNumber)
 /**
   * @brief  Enables or disables the DBG Freeze for CAN.
   * @param  CANx: where x can be 1 or 2 to to select the CAN peripheral.
-  * @param  NewState: new state of the CAN peripheral. 
+  * @param  NewState: new state of the CAN peripheral.
   *          This parameter can be: ENABLE (CAN reception/transmission is frozen
-  *          during debug. Reception FIFOs can still be accessed/controlled normally) 
+  *          during debug. Reception FIFOs can still be accessed/controlled normally)
   *          or DISABLE (CAN is working during debug).
   * @retval None
   */
@@ -470,7 +470,7 @@ void CAN_DBGFreeze(CAN_TypeDef* CANx, FunctionalState NewState)
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
   assert_param(IS_FUNCTIONAL_STATE(NewState));
-  
+
   if (NewState != DISABLE)
   {
     /* Enable Debug Freeze  */
@@ -485,13 +485,13 @@ void CAN_DBGFreeze(CAN_TypeDef* CANx, FunctionalState NewState)
 
 /**
   * @brief  Enables or disables the CAN Time TriggerOperation communication mode.
-  * @note   DLC must be programmed as 8 in order Time Stamp (2 bytes) to be 
-  *         sent over the CAN bus.  
+  * @note   DLC must be programmed as 8 in order Time Stamp (2 bytes) to be
+  *         sent over the CAN bus.
   * @param  CANx: where x can be 1 or 2 to to select the CAN peripheral.
   * @param  NewState: Mode new state. This parameter can be: ENABLE or DISABLE.
   *         When enabled, Time stamp (TIME[15:0]) value is  sent in the last two
-  *         data bytes of the 8-byte message: TIME[7:0] in data byte 6 and TIME[15:8] 
-  *         in data byte 7. 
+  *         data bytes of the 8-byte message: TIME[7:0] in data byte 6 and TIME[15:8]
+  *         in data byte 7.
   * @retval None
   */
 void CAN_TTComModeCmd(CAN_TypeDef* CANx, FunctionalState NewState)
@@ -526,17 +526,17 @@ void CAN_TTComModeCmd(CAN_TypeDef* CANx, FunctionalState NewState)
 
 
 /** @defgroup CAN_Group2 CAN Frames Transmission functions
- *  @brief    CAN Frames Transmission functions 
+ *  @brief    CAN Frames Transmission functions
  *
-@verbatim    
+@verbatim
  ===============================================================================
                 ##### CAN Frames Transmission functions #####
- ===============================================================================  
-    [..] This section provides functions allowing to 
+ ===============================================================================
+    [..] This section provides functions allowing to
          (+) Initiate and transmit a CAN frame message (if there is an empty mailbox).
          (+) Check the transmission status of a CAN Frame.
          (+) Cancel a transmit request.
-   
+
 @endverbatim
   * @{
   */
@@ -581,7 +581,7 @@ uint8_t CAN_Transmit(CAN_TypeDef* CANx, CanTxMsg* TxMessage)
     CANx->sTxMailBox[transmit_mailbox].TIR &= TMIDxR_TXRQ;
     if (TxMessage->IDE == CAN_Id_Standard)
     {
-      assert_param(IS_CAN_STDID(TxMessage->StdId));  
+      assert_param(IS_CAN_STDID(TxMessage->StdId));
       CANx->sTxMailBox[transmit_mailbox].TIR |= ((TxMessage->StdId << 21) | \
                                                   TxMessage->RTR);
     }
@@ -592,18 +592,18 @@ uint8_t CAN_Transmit(CAN_TypeDef* CANx, CanTxMsg* TxMessage)
                                                   TxMessage->IDE | \
                                                   TxMessage->RTR);
     }
-    
+
     /* Set up the DLC */
     TxMessage->DLC &= (uint8_t)0x0000000F;
     CANx->sTxMailBox[transmit_mailbox].TDTR &= (uint32_t)0xFFFFFFF0;
     CANx->sTxMailBox[transmit_mailbox].TDTR |= TxMessage->DLC;
 
     /* Set up the data field */
-    CANx->sTxMailBox[transmit_mailbox].TDLR = (((uint32_t)TxMessage->Data[3] << 24) | 
+    CANx->sTxMailBox[transmit_mailbox].TDLR = (((uint32_t)TxMessage->Data[3] << 24) |
                                              ((uint32_t)TxMessage->Data[2] << 16) |
-                                             ((uint32_t)TxMessage->Data[1] << 8) | 
+                                             ((uint32_t)TxMessage->Data[1] << 8) |
                                              ((uint32_t)TxMessage->Data[0]));
-    CANx->sTxMailBox[transmit_mailbox].TDHR = (((uint32_t)TxMessage->Data[7] << 24) | 
+    CANx->sTxMailBox[transmit_mailbox].TDHR = (((uint32_t)TxMessage->Data[7] << 24) |
                                              ((uint32_t)TxMessage->Data[6] << 16) |
                                              ((uint32_t)TxMessage->Data[5] << 8) |
                                              ((uint32_t)TxMessage->Data[4]));
@@ -617,7 +617,7 @@ uint8_t CAN_Transmit(CAN_TypeDef* CANx, CanTxMsg* TxMessage)
   * @brief  Checks the transmission status of a CAN Frame.
   * @param  CANx: where x can be 1 to select the CAN1 peripheral.
   * @param  TransmitMailbox: the number of the mailbox that is used for transmission.
-  * @retval CAN_TxStatus_Ok if the CAN driver transmits the message, 
+  * @retval CAN_TxStatus_Ok if the CAN driver transmits the message,
   *         CAN_TxStatus_Failed in an other case.
   */
 uint8_t CAN_TransmitStatus(CAN_TypeDef* CANx, uint8_t TransmitMailbox)
@@ -627,16 +627,16 @@ uint8_t CAN_TransmitStatus(CAN_TypeDef* CANx, uint8_t TransmitMailbox)
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
   assert_param(IS_CAN_TRANSMITMAILBOX(TransmitMailbox));
- 
+
   switch (TransmitMailbox)
   {
-    case (CAN_TXMAILBOX_0): 
+    case (CAN_TXMAILBOX_0):
       state =   CANx->TSR &  (CAN_TSR_RQCP0 | CAN_TSR_TXOK0 | CAN_TSR_TME0);
       break;
-    case (CAN_TXMAILBOX_1): 
+    case (CAN_TXMAILBOX_1):
       state =   CANx->TSR &  (CAN_TSR_RQCP1 | CAN_TSR_TXOK1 | CAN_TSR_TME1);
       break;
-    case (CAN_TXMAILBOX_2): 
+    case (CAN_TXMAILBOX_2):
       state =   CANx->TSR &  (CAN_TSR_RQCP2 | CAN_TSR_TXOK2 | CAN_TSR_TME2);
       break;
     default:
@@ -698,17 +698,17 @@ void CAN_CancelTransmit(CAN_TypeDef* CANx, uint8_t Mailbox)
 
 
 /** @defgroup CAN_Group3 CAN Frames Reception functions
- *  @brief    CAN Frames Reception functions 
+ *  @brief    CAN Frames Reception functions
  *
-@verbatim    
+@verbatim
  ===============================================================================
                   ##### CAN Frames Reception functions #####
- ===============================================================================  
-    [..] This section provides functions allowing to 
+ ===============================================================================
+    [..] This section provides functions allowing to
          (+) Receive a correct CAN frame.
          (+) Release a specified receive FIFO (2 FIFOs are available).
          (+) Return the number of the pending received CAN frames.
-   
+
 @endverbatim
   * @{
   */
@@ -736,7 +736,7 @@ void CAN_Receive(CAN_TypeDef* CANx, uint8_t FIFONumber, CanRxMsg* RxMessage)
   {
     RxMessage->ExtId = (uint32_t)0x1FFFFFFF & (CANx->sFIFOMailBox[FIFONumber].RIR >> 3);
   }
-  
+
   RxMessage->RTR = (uint8_t)0x02 & CANx->sFIFOMailBox[FIFONumber].RIR;
   /* Get the DLC */
   RxMessage->DLC = (uint8_t)0x0F & CANx->sFIFOMailBox[FIFONumber].RDTR;
@@ -819,36 +819,36 @@ uint8_t CAN_MessagePending(CAN_TypeDef* CANx, uint8_t FIFONumber)
 
 
 /** @defgroup CAN_Group4 CAN Operation modes functions
- *  @brief    CAN Operation modes functions 
+ *  @brief    CAN Operation modes functions
  *
-@verbatim    
+@verbatim
  ===============================================================================
                     ##### CAN Operation modes functions #####
- ===============================================================================  
+ ===============================================================================
     [..] This section provides functions allowing to select the CAN Operation modes:
          (+) sleep mode.
-         (+) normal mode. 
+         (+) normal mode.
          (+) initialization mode.
-   
+
 @endverbatim
   * @{
   */
-  
-  
+
+
 /**
   * @brief  Selects the CAN Operation mode.
   * @param  CAN_OperatingMode: CAN Operating Mode.
   *         This parameter can be one of @ref CAN_OperatingMode_TypeDef enumeration.
-  * @retval status of the requested mode which can be: 
-  *         - CAN_ModeStatus_Failed:  CAN failed entering the specific mode 
-  *         - CAN_ModeStatus_Success: CAN Succeed entering the specific mode 
+  * @retval status of the requested mode which can be:
+  *         - CAN_ModeStatus_Failed:  CAN failed entering the specific mode
+  *         - CAN_ModeStatus_Success: CAN Succeed entering the specific mode
   */
 uint8_t CAN_OperatingModeRequest(CAN_TypeDef* CANx, uint8_t CAN_OperatingMode)
 {
   uint8_t status = CAN_ModeStatus_Failed;
-  
+
   /* Timeout for INAK or also for SLAK bits*/
-  uint32_t timeout = INAK_TIMEOUT; 
+  uint32_t timeout = INAK_TIMEOUT;
 
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
@@ -927,13 +927,13 @@ uint8_t CAN_OperatingModeRequest(CAN_TypeDef* CANx, uint8_t CAN_OperatingMode)
 uint8_t CAN_Sleep(CAN_TypeDef* CANx)
 {
   uint8_t sleepstatus = CAN_Sleep_Failed;
-  
+
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
-    
+
   /* Request Sleep mode */
    CANx->MCR = (((CANx->MCR) & (uint32_t)(~(uint32_t)CAN_MCR_INRQ)) | CAN_MCR_SLEEP);
-   
+
   /* Sleep mode status */
   if ((CANx->MSR & (CAN_MSR_SLAK|CAN_MSR_INAK)) == CAN_MSR_SLAK)
   {
@@ -953,13 +953,13 @@ uint8_t CAN_WakeUp(CAN_TypeDef* CANx)
 {
   uint32_t wait_slak = SLAK_TIMEOUT;
   uint8_t wakeupstatus = CAN_WakeUp_Failed;
-  
+
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
-    
+
   /* Wake up request */
   CANx->MCR &= ~(uint32_t)CAN_MCR_SLEEP;
-    
+
   /* Sleep mode status */
   while(((CANx->MSR & CAN_MSR_SLAK) == CAN_MSR_SLAK)&&(wait_slak!=0x00))
   {
@@ -979,13 +979,13 @@ uint8_t CAN_WakeUp(CAN_TypeDef* CANx)
 
 
 /** @defgroup CAN_Group5 CAN Bus Error management functions
- *  @brief    CAN Bus Error management functions 
+ *  @brief    CAN Bus Error management functions
  *
-@verbatim    
+@verbatim
  ===============================================================================
                   ##### CAN Bus Error management functions #####
- ===============================================================================  
-    [..] This section provides functions allowing to 
+ ===============================================================================
+    [..] This section provides functions allowing to
          (+) Return the CANx's last error code (LEC).
          (+) Return the CANx Receive Error Counter (REC).
          (+) Return the LSB of the 9-bit CANx Transmit Error Counter(TEC).
@@ -993,59 +993,59 @@ uint8_t CAN_WakeUp(CAN_TypeDef* CANx)
          (@) If TEC is greater than 255, The CAN is in bus-off state.
          (@) If REC or TEC are greater than 96, an Error warning flag occurs.
          (@) If REC or TEC are greater than 127, an Error Passive Flag occurs.
-                        
+
 @endverbatim
   * @{
   */
-  
+
 /**
   * @brief  Returns the CANx's last error code (LEC).
   * @param  CANx: where x can be 1 to select the CAN1 peripheral.
-  * @retval Error code: 
-  *          - CAN_ERRORCODE_NoErr: No Error  
+  * @retval Error code:
+  *          - CAN_ERRORCODE_NoErr: No Error
   *          - CAN_ERRORCODE_StuffErr: Stuff Error
   *          - CAN_ERRORCODE_FormErr: Form Error
   *          - CAN_ERRORCODE_ACKErr : Acknowledgment Error
   *          - CAN_ERRORCODE_BitRecessiveErr: Bit Recessive Error
   *          - CAN_ERRORCODE_BitDominantErr: Bit Dominant Error
   *          - CAN_ERRORCODE_CRCErr: CRC Error
-  *          - CAN_ERRORCODE_SoftwareSetErr: Software Set Error  
+  *          - CAN_ERRORCODE_SoftwareSetErr: Software Set Error
   */
 uint8_t CAN_GetLastErrorCode(CAN_TypeDef* CANx)
 {
   uint8_t errorcode=0;
-  
+
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
-  
+
   /* Get the error code*/
   errorcode = (((uint8_t)CANx->ESR) & (uint8_t)CAN_ESR_LEC);
-  
+
   /* Return the error code*/
   return errorcode;
 }
 
 /**
   * @brief  Returns the CANx Receive Error Counter (REC).
-  * @note   In case of an error during reception, this counter is incremented 
-  *         by 1 or by 8 depending on the error condition as defined by the CAN 
-  *         standard. After every successful reception, the counter is 
-  *         decremented by 1 or reset to 120 if its value was higher than 128. 
-  *         When the counter value exceeds 127, the CAN controller enters the 
-  *         error passive state.  
-  * @param  CANx: where x can be 1 or 2 to to select the CAN peripheral.  
-  * @retval CAN Receive Error Counter. 
+  * @note   In case of an error during reception, this counter is incremented
+  *         by 1 or by 8 depending on the error condition as defined by the CAN
+  *         standard. After every successful reception, the counter is
+  *         decremented by 1 or reset to 120 if its value was higher than 128.
+  *         When the counter value exceeds 127, the CAN controller enters the
+  *         error passive state.
+  * @param  CANx: where x can be 1 or 2 to to select the CAN peripheral.
+  * @retval CAN Receive Error Counter.
   */
 uint8_t CAN_GetReceiveErrorCounter(CAN_TypeDef* CANx)
 {
   uint8_t counter=0;
-  
+
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
-  
+
   /* Get the Receive Error Counter*/
   counter = (uint8_t)((CANx->ESR & CAN_ESR_REC)>> 24);
-  
+
   /* Return the Receive Error Counter*/
   return counter;
 }
@@ -1054,18 +1054,18 @@ uint8_t CAN_GetReceiveErrorCounter(CAN_TypeDef* CANx)
 /**
   * @brief  Returns the LSB of the 9-bit CANx Transmit Error Counter(TEC).
   * @param  CANx: where x can be 1 or 2 to to select the CAN peripheral.
-  * @retval LSB of the 9-bit CAN Transmit Error Counter. 
+  * @retval LSB of the 9-bit CAN Transmit Error Counter.
   */
 uint8_t CAN_GetLSBTransmitErrorCounter(CAN_TypeDef* CANx)
 {
   uint8_t counter=0;
-  
+
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
-  
+
   /* Get the LSB of the 9-bit CANx Transmit Error Counter(TEC) */
   counter = (uint8_t)((CANx->ESR & CAN_ESR_TEC)>> 16);
-  
+
   /* Return the LSB of the 9-bit CANx Transmit Error Counter(TEC) */
   return counter;
 }
@@ -1076,139 +1076,139 @@ uint8_t CAN_GetLSBTransmitErrorCounter(CAN_TypeDef* CANx)
 /** @defgroup CAN_Group6 Interrupts and flags management functions
  *  @brief   Interrupts and flags management functions
  *
-@verbatim   
+@verbatim
  ===============================================================================
               ##### Interrupts and flags management functions #####
- ===============================================================================  
-    [..] This section provides functions allowing to configure the CAN Interrupts 
+ ===============================================================================
+    [..] This section provides functions allowing to configure the CAN Interrupts
          and to get the status and clear flags and Interrupts pending bits.
     [..] The CAN provides 14 Interrupts sources and 15 Flags:
-   
+
   *** Flags ***
   =============
-    [..] The 15 flags can be divided on 4 groups: 
+    [..] The 15 flags can be divided on 4 groups:
          (+) Transmit Flags:
-             (++) CAN_FLAG_RQCP0. 
-             (++) CAN_FLAG_RQCP1. 
+             (++) CAN_FLAG_RQCP0.
+             (++) CAN_FLAG_RQCP1.
              (++) CAN_FLAG_RQCP2: Request completed MailBoxes 0, 1 and 2  Flags
-                  Set when when the last request (transmit or abort) has 
-                  been performed. 
+                  Set when when the last request (transmit or abort) has
+                  been performed.
          (+) Receive Flags:
              (++) CAN_FLAG_FMP0.
-             (++) CAN_FLAG_FMP1: FIFO 0 and 1 Message Pending Flags; 
+             (++) CAN_FLAG_FMP1: FIFO 0 and 1 Message Pending Flags;
                   Set to signal that messages are pending in the receive FIFO.
-                  These Flags are cleared only by hardware. 
+                  These Flags are cleared only by hardware.
              (++) CAN_FLAG_FF0.
-             (++) CAN_FLAG_FF1: FIFO 0 and 1 Full Flags; 
-                  Set when three messages are stored in the selected FIFO.                        
-             (++) CAN_FLAG_FOV0.              
-             (++) CAN_FLAG_FOV1: FIFO 0 and 1 Overrun Flags; 
-                  Set when a new message has been received and passed the filter 
-                  while the FIFO was full.         
-         (+) Operating Mode Flags: 
-             (++) CAN_FLAG_WKU: Wake up Flag; 
-                  Set to signal that a SOF bit has been detected while the CAN 
-                  hardware was in Sleep mode. 
+             (++) CAN_FLAG_FF1: FIFO 0 and 1 Full Flags;
+                  Set when three messages are stored in the selected FIFO.
+             (++) CAN_FLAG_FOV0.
+             (++) CAN_FLAG_FOV1: FIFO 0 and 1 Overrun Flags;
+                  Set when a new message has been received and passed the filter
+                  while the FIFO was full.
+         (+) Operating Mode Flags:
+             (++) CAN_FLAG_WKU: Wake up Flag;
+                  Set to signal that a SOF bit has been detected while the CAN
+                  hardware was in Sleep mode.
              (++) CAN_FLAG_SLAK: Sleep acknowledge Flag;
-                  Set to signal that the CAN has entered Sleep Mode. 
-         (+) Error Flags:  
+                  Set to signal that the CAN has entered Sleep Mode.
+         (+) Error Flags:
              (++) CAN_FLAG_EWG: Error Warning Flag;
-                  Set when the warning limit has been reached (Receive Error Counter 
-                  or Transmit Error Counter greater than 96). 
+                  Set when the warning limit has been reached (Receive Error Counter
+                  or Transmit Error Counter greater than 96).
                   This Flag is cleared only by hardware.
              (++) CAN_FLAG_EPV: Error Passive Flag;
-                  Set when the Error Passive limit has been reached (Receive Error 
+                  Set when the Error Passive limit has been reached (Receive Error
                   Counter or Transmit Error Counter greater than 127).
                   This Flag is cleared only by hardware.
              (++) CAN_FLAG_BOF: Bus-Off Flag;
-                  Set when CAN enters the bus-off state. The bus-off state is 
+                  Set when CAN enters the bus-off state. The bus-off state is
                   entered on TEC overflow, greater than 255.
                   This Flag is cleared only by hardware.
              (++) CAN_FLAG_LEC: Last error code Flag;
-                  Set If a message has been transferred (reception or transmission) 
-                  with error, and the error code is hold.                      
-  
+                  Set If a message has been transferred (reception or transmission)
+                  with error, and the error code is hold.
+
   *** Interrupts ***
   ==================
-    [..] The 14 interrupts can be divided on 4 groups: 
-         (+) Transmit interrupt:   
+    [..] The 14 interrupts can be divided on 4 groups:
+         (+) Transmit interrupt:
              (++) CAN_IT_TME: Transmit mailbox empty Interrupt;
-                  If enabled, this interrupt source is pending when no transmit 
-                  request are pending for Tx mailboxes.      
-         (+) Receive Interrupts:   
+                  If enabled, this interrupt source is pending when no transmit
+                  request are pending for Tx mailboxes.
+         (+) Receive Interrupts:
              (++) CAN_IT_FMP0.
              (++) CAN_IT_FMP1: FIFO 0 and FIFO1 message pending Interrupts;
-                  If enabled, these interrupt sources are pending when messages 
+                  If enabled, these interrupt sources are pending when messages
                   are pending in the receive FIFO.
                   The corresponding interrupt pending bits are cleared only by hardware.
-             (++) CAN_IT_FF0.              
+             (++) CAN_IT_FF0.
              (++) CAN_IT_FF1: FIFO 0 and FIFO1 full Interrupts;
-                  If enabled, these interrupt sources are pending when three messages 
+                  If enabled, these interrupt sources are pending when three messages
                   are stored in the selected FIFO.
-             (++) CAN_IT_FOV0.        
-             (++) CAN_IT_FOV1: FIFO 0 and FIFO1 overrun Interrupts;        
-                  If enabled, these interrupt sources are pending when a new message 
+             (++) CAN_IT_FOV0.
+             (++) CAN_IT_FOV1: FIFO 0 and FIFO1 overrun Interrupts;
+                  If enabled, these interrupt sources are pending when a new message
                   has been received and passed the filter while the FIFO was full.
-         (+) Operating Mode Interrupts:    
+         (+) Operating Mode Interrupts:
              (++) CAN_IT_WKU: Wake-up Interrupt;
-                  If enabled, this interrupt source is pending when a SOF bit has 
+                  If enabled, this interrupt source is pending when a SOF bit has
                   been detected while the CAN hardware was in Sleep mode.
              (++) CAN_IT_SLK: Sleep acknowledge Interrupt:
-                  If enabled, this interrupt source is pending when the CAN has 
-                  entered Sleep Mode.       
-         (+) Error Interrupts:     
-             (++) CAN_IT_EWG: Error warning Interrupt; 
-                  If enabled, this interrupt source is pending when the warning limit 
-                  has been reached (Receive Error Counter or Transmit Error Counter=96). 
-             (++) CAN_IT_EPV: Error passive Interrupt;        
-                  If enabled, this interrupt source is pending when the Error Passive 
+                  If enabled, this interrupt source is pending when the CAN has
+                  entered Sleep Mode.
+         (+) Error Interrupts:
+             (++) CAN_IT_EWG: Error warning Interrupt;
+                  If enabled, this interrupt source is pending when the warning limit
+                  has been reached (Receive Error Counter or Transmit Error Counter=96).
+             (++) CAN_IT_EPV: Error passive Interrupt;
+                  If enabled, this interrupt source is pending when the Error Passive
                   limit has been reached (Receive Error Counter or Transmit Error Counter>127).
              (++) CAN_IT_BOF: Bus-off Interrupt;
-                  If enabled, this interrupt source is pending when CAN enters 
-                  the bus-off state. The bus-off state is entered on TEC overflow, 
+                  If enabled, this interrupt source is pending when CAN enters
+                  the bus-off state. The bus-off state is entered on TEC overflow,
                   greater than 255.
                   This Flag is cleared only by hardware.
-             (++) CAN_IT_LEC: Last error code Interrupt;        
-                  If enabled, this interrupt source is pending when a message has 
-                  been transferred (reception or transmission) with error and the 
+             (++) CAN_IT_LEC: Last error code Interrupt;
+                  If enabled, this interrupt source is pending when a message has
+                  been transferred (reception or transmission) with error and the
                   error code is hold.
              (++) CAN_IT_ERR: Error Interrupt;
-                  If enabled, this interrupt source is pending when an error condition 
-                  is pending.      
-    [..] Managing the CAN controller events: 
-         The user should identify which mode will be used in his application to manage 
+                  If enabled, this interrupt source is pending when an error condition
+                  is pending.
+    [..] Managing the CAN controller events:
+         The user should identify which mode will be used in his application to manage
          the CAN controller events: Polling mode or Interrupt mode.
          (+) In the Polling Mode it is advised to use the following functions:
-             (++) CAN_GetFlagStatus() : to check if flags events occur. 
+             (++) CAN_GetFlagStatus() : to check if flags events occur.
              (++) CAN_ClearFlag()     : to clear the flags events.
          (+) In the Interrupt Mode it is advised to use the following functions:
              (++) CAN_ITConfig()       : to enable or disable the interrupt source.
              (++) CAN_GetITStatus()    : to check if Interrupt occurs.
-             (++) CAN_ClearITPendingBit() : to clear the Interrupt pending Bit 
+             (++) CAN_ClearITPendingBit() : to clear the Interrupt pending Bit
                   (corresponding Flag).
-                  This function has no impact on CAN_IT_FMP0 and CAN_IT_FMP1 Interrupts 
-                  pending bits since there are cleared only by hardware. 
-  
+                  This function has no impact on CAN_IT_FMP0 and CAN_IT_FMP1 Interrupts
+                  pending bits since there are cleared only by hardware.
+
 @endverbatim
   * @{
-  */ 
+  */
 /**
   * @brief  Enables or disables the specified CANx interrupts.
   * @param  CANx: where x can be 1 or 2 to to select the CAN peripheral.
   * @param  CAN_IT: specifies the CAN interrupt sources to be enabled or disabled.
-  *          This parameter can be: 
-  *            @arg CAN_IT_TME: Transmit mailbox empty Interrupt 
-  *            @arg CAN_IT_FMP0: FIFO 0 message pending Interrupt 
+  *          This parameter can be:
+  *            @arg CAN_IT_TME: Transmit mailbox empty Interrupt
+  *            @arg CAN_IT_FMP0: FIFO 0 message pending Interrupt
   *            @arg CAN_IT_FF0: FIFO 0 full Interrupt
   *            @arg CAN_IT_FOV0: FIFO 0 overrun Interrupt
-  *            @arg CAN_IT_FMP1: FIFO 1 message pending Interrupt 
+  *            @arg CAN_IT_FMP1: FIFO 1 message pending Interrupt
   *            @arg CAN_IT_FF1: FIFO 1 full Interrupt
   *            @arg CAN_IT_FOV1: FIFO 1 overrun Interrupt
   *            @arg CAN_IT_WKU: Wake-up Interrupt
-  *            @arg CAN_IT_SLK: Sleep acknowledge Interrupt  
+  *            @arg CAN_IT_SLK: Sleep acknowledge Interrupt
   *            @arg CAN_IT_EWG: Error warning Interrupt
   *            @arg CAN_IT_EPV: Error passive Interrupt
-  *            @arg CAN_IT_BOF: Bus-off Interrupt  
+  *            @arg CAN_IT_BOF: Bus-off Interrupt
   *            @arg CAN_IT_LEC: Last error code Interrupt
   *            @arg CAN_IT_ERR: Error Interrupt
   * @param  NewState: new state of the CAN interrupts.
@@ -1241,95 +1241,95 @@ void CAN_ITConfig(CAN_TypeDef* CANx, uint32_t CAN_IT, FunctionalState NewState)
   *            @arg CAN_FLAG_RQCP0: Request MailBox0 Flag
   *            @arg CAN_FLAG_RQCP1: Request MailBox1 Flag
   *            @arg CAN_FLAG_RQCP2: Request MailBox2 Flag
-  *            @arg CAN_FLAG_FMP0: FIFO 0 Message Pending Flag   
-  *            @arg CAN_FLAG_FF0: FIFO 0 Full Flag       
-  *            @arg CAN_FLAG_FOV0: FIFO 0 Overrun Flag 
-  *            @arg CAN_FLAG_FMP1: FIFO 1 Message Pending Flag   
-  *            @arg CAN_FLAG_FF1: FIFO 1 Full Flag        
-  *            @arg CAN_FLAG_FOV1: FIFO 1 Overrun Flag     
+  *            @arg CAN_FLAG_FMP0: FIFO 0 Message Pending Flag
+  *            @arg CAN_FLAG_FF0: FIFO 0 Full Flag
+  *            @arg CAN_FLAG_FOV0: FIFO 0 Overrun Flag
+  *            @arg CAN_FLAG_FMP1: FIFO 1 Message Pending Flag
+  *            @arg CAN_FLAG_FF1: FIFO 1 Full Flag
+  *            @arg CAN_FLAG_FOV1: FIFO 1 Overrun Flag
   *            @arg CAN_FLAG_WKU: Wake up Flag
-  *            @arg CAN_FLAG_SLAK: Sleep acknowledge Flag 
+  *            @arg CAN_FLAG_SLAK: Sleep acknowledge Flag
   *            @arg CAN_FLAG_EWG: Error Warning Flag
-  *            @arg CAN_FLAG_EPV: Error Passive Flag  
-  *            @arg CAN_FLAG_BOF: Bus-Off Flag    
-  *            @arg CAN_FLAG_LEC: Last error code Flag      
+  *            @arg CAN_FLAG_EPV: Error Passive Flag
+  *            @arg CAN_FLAG_BOF: Bus-Off Flag
+  *            @arg CAN_FLAG_LEC: Last error code Flag
   * @retval The new state of CAN_FLAG (SET or RESET).
   */
 FlagStatus CAN_GetFlagStatus(CAN_TypeDef* CANx, uint32_t CAN_FLAG)
 {
   FlagStatus bitstatus = RESET;
-  
+
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
   assert_param(IS_CAN_GET_FLAG(CAN_FLAG));
-  
+
 
   if((CAN_FLAG & CAN_FLAGS_ESR) != (uint32_t)RESET)
-  { 
+  {
     /* Check the status of the specified CAN flag */
     if ((CANx->ESR & (CAN_FLAG & 0x000FFFFF)) != (uint32_t)RESET)
-    { 
+    {
       /* CAN_FLAG is set */
       bitstatus = SET;
     }
     else
-    { 
+    {
       /* CAN_FLAG is reset */
       bitstatus = RESET;
     }
   }
   else if((CAN_FLAG & CAN_FLAGS_MSR) != (uint32_t)RESET)
-  { 
+  {
     /* Check the status of the specified CAN flag */
     if ((CANx->MSR & (CAN_FLAG & 0x000FFFFF)) != (uint32_t)RESET)
-    { 
+    {
       /* CAN_FLAG is set */
       bitstatus = SET;
     }
     else
-    { 
+    {
       /* CAN_FLAG is reset */
       bitstatus = RESET;
     }
   }
   else if((CAN_FLAG & CAN_FLAGS_TSR) != (uint32_t)RESET)
-  { 
+  {
     /* Check the status of the specified CAN flag */
     if ((CANx->TSR & (CAN_FLAG & 0x000FFFFF)) != (uint32_t)RESET)
-    { 
+    {
       /* CAN_FLAG is set */
       bitstatus = SET;
     }
     else
-    { 
+    {
       /* CAN_FLAG is reset */
       bitstatus = RESET;
     }
   }
   else if((CAN_FLAG & CAN_FLAGS_RF0R) != (uint32_t)RESET)
-  { 
+  {
     /* Check the status of the specified CAN flag */
     if ((CANx->RF0R & (CAN_FLAG & 0x000FFFFF)) != (uint32_t)RESET)
-    { 
+    {
       /* CAN_FLAG is set */
       bitstatus = SET;
     }
     else
-    { 
+    {
       /* CAN_FLAG is reset */
       bitstatus = RESET;
     }
   }
   else /* If(CAN_FLAG & CAN_FLAGS_RF1R != (uint32_t)RESET) */
-  { 
+  {
     /* Check the status of the specified CAN flag */
     if ((uint32_t)(CANx->RF1R & (CAN_FLAG & 0x000FFFFF)) != (uint32_t)RESET)
-    { 
+    {
       /* CAN_FLAG is set */
       bitstatus = SET;
     }
     else
-    { 
+    {
       /* CAN_FLAG is reset */
       bitstatus = RESET;
     }
@@ -1345,14 +1345,14 @@ FlagStatus CAN_GetFlagStatus(CAN_TypeDef* CANx, uint32_t CAN_FLAG)
   *          This parameter can be one of the following values:
   *            @arg CAN_FLAG_RQCP0: Request MailBox0 Flag
   *            @arg CAN_FLAG_RQCP1: Request MailBox1 Flag
-  *            @arg CAN_FLAG_RQCP2: Request MailBox2 Flag 
-  *            @arg CAN_FLAG_FF0: FIFO 0 Full Flag       
-  *            @arg CAN_FLAG_FOV0: FIFO 0 Overrun Flag  
-  *            @arg CAN_FLAG_FF1: FIFO 1 Full Flag        
-  *            @arg CAN_FLAG_FOV1: FIFO 1 Overrun Flag     
+  *            @arg CAN_FLAG_RQCP2: Request MailBox2 Flag
+  *            @arg CAN_FLAG_FF0: FIFO 0 Full Flag
+  *            @arg CAN_FLAG_FOV0: FIFO 0 Overrun Flag
+  *            @arg CAN_FLAG_FF1: FIFO 1 Full Flag
+  *            @arg CAN_FLAG_FOV1: FIFO 1 Overrun Flag
   *            @arg CAN_FLAG_WKU: Wake up Flag
-  *            @arg CAN_FLAG_SLAK: Sleep acknowledge Flag    
-  *            @arg CAN_FLAG_LEC: Last error code Flag        
+  *            @arg CAN_FLAG_SLAK: Sleep acknowledge Flag
+  *            @arg CAN_FLAG_LEC: Last error code Flag
   * @retval None
   */
 void CAN_ClearFlag(CAN_TypeDef* CANx, uint32_t CAN_FLAG)
@@ -1361,7 +1361,7 @@ void CAN_ClearFlag(CAN_TypeDef* CANx, uint32_t CAN_FLAG)
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
   assert_param(IS_CAN_CLEAR_FLAG(CAN_FLAG));
-  
+
   if (CAN_FLAG == CAN_FLAG_LEC) /* ESR register */
   {
     /* Clear the selected CAN flags */
@@ -1399,18 +1399,18 @@ void CAN_ClearFlag(CAN_TypeDef* CANx, uint32_t CAN_FLAG)
   * @param  CANx: where x can be 1 or 2 to to select the CAN peripheral.
   * @param  CAN_IT: specifies the CAN interrupt source to check.
   *          This parameter can be one of the following values:
-  *            @arg CAN_IT_TME: Transmit mailbox empty Interrupt 
-  *            @arg CAN_IT_FMP0: FIFO 0 message pending Interrupt 
+  *            @arg CAN_IT_TME: Transmit mailbox empty Interrupt
+  *            @arg CAN_IT_FMP0: FIFO 0 message pending Interrupt
   *            @arg CAN_IT_FF0: FIFO 0 full Interrupt
   *            @arg CAN_IT_FOV0: FIFO 0 overrun Interrupt
-  *            @arg CAN_IT_FMP1: FIFO 1 message pending Interrupt 
+  *            @arg CAN_IT_FMP1: FIFO 1 message pending Interrupt
   *            @arg CAN_IT_FF1: FIFO 1 full Interrupt
   *            @arg CAN_IT_FOV1: FIFO 1 overrun Interrupt
   *            @arg CAN_IT_WKU: Wake-up Interrupt
-  *            @arg CAN_IT_SLK: Sleep acknowledge Interrupt  
+  *            @arg CAN_IT_SLK: Sleep acknowledge Interrupt
   *            @arg CAN_IT_EWG: Error warning Interrupt
   *            @arg CAN_IT_EPV: Error passive Interrupt
-  *            @arg CAN_IT_BOF: Bus-off Interrupt  
+  *            @arg CAN_IT_BOF: Bus-off Interrupt
   *            @arg CAN_IT_LEC: Last error code Interrupt
   *            @arg CAN_IT_ERR: Error Interrupt
   * @retval The current state of CAN_IT (SET or RESET).
@@ -1421,7 +1421,7 @@ ITStatus CAN_GetITStatus(CAN_TypeDef* CANx, uint32_t CAN_IT)
   /* Check the parameters */
   assert_param(IS_CAN_ALL_PERIPH(CANx));
   assert_param(IS_CAN_IT(CAN_IT));
-  
+
   /* check the interrupt enable bit */
  if((CANx->IER & CAN_IT) != RESET)
  {
@@ -1430,59 +1430,59 @@ ITStatus CAN_GetITStatus(CAN_TypeDef* CANx, uint32_t CAN_IT)
     {
       case CAN_IT_TME:
         /* Check CAN_TSR_RQCPx bits */
-        itstatus = CheckITStatus(CANx->TSR, CAN_TSR_RQCP0|CAN_TSR_RQCP1|CAN_TSR_RQCP2);  
+        itstatus = CheckITStatus(CANx->TSR, CAN_TSR_RQCP0|CAN_TSR_RQCP1|CAN_TSR_RQCP2);
         break;
       case CAN_IT_FMP0:
         /* Check CAN_RF0R_FMP0 bit */
-        itstatus = CheckITStatus(CANx->RF0R, CAN_RF0R_FMP0);  
+        itstatus = CheckITStatus(CANx->RF0R, CAN_RF0R_FMP0);
         break;
       case CAN_IT_FF0:
         /* Check CAN_RF0R_FULL0 bit */
-        itstatus = CheckITStatus(CANx->RF0R, CAN_RF0R_FULL0);  
+        itstatus = CheckITStatus(CANx->RF0R, CAN_RF0R_FULL0);
         break;
       case CAN_IT_FOV0:
         /* Check CAN_RF0R_FOVR0 bit */
-        itstatus = CheckITStatus(CANx->RF0R, CAN_RF0R_FOVR0);  
+        itstatus = CheckITStatus(CANx->RF0R, CAN_RF0R_FOVR0);
         break;
       case CAN_IT_FMP1:
         /* Check CAN_RF1R_FMP1 bit */
-        itstatus = CheckITStatus(CANx->RF1R, CAN_RF1R_FMP1);  
+        itstatus = CheckITStatus(CANx->RF1R, CAN_RF1R_FMP1);
         break;
       case CAN_IT_FF1:
         /* Check CAN_RF1R_FULL1 bit */
-        itstatus = CheckITStatus(CANx->RF1R, CAN_RF1R_FULL1);  
+        itstatus = CheckITStatus(CANx->RF1R, CAN_RF1R_FULL1);
         break;
       case CAN_IT_FOV1:
         /* Check CAN_RF1R_FOVR1 bit */
-        itstatus = CheckITStatus(CANx->RF1R, CAN_RF1R_FOVR1);  
+        itstatus = CheckITStatus(CANx->RF1R, CAN_RF1R_FOVR1);
         break;
       case CAN_IT_WKU:
         /* Check CAN_MSR_WKUI bit */
-        itstatus = CheckITStatus(CANx->MSR, CAN_MSR_WKUI);  
+        itstatus = CheckITStatus(CANx->MSR, CAN_MSR_WKUI);
         break;
       case CAN_IT_SLK:
         /* Check CAN_MSR_SLAKI bit */
-        itstatus = CheckITStatus(CANx->MSR, CAN_MSR_SLAKI);  
+        itstatus = CheckITStatus(CANx->MSR, CAN_MSR_SLAKI);
         break;
       case CAN_IT_EWG:
         /* Check CAN_ESR_EWGF bit */
-        itstatus = CheckITStatus(CANx->ESR, CAN_ESR_EWGF);  
+        itstatus = CheckITStatus(CANx->ESR, CAN_ESR_EWGF);
         break;
       case CAN_IT_EPV:
         /* Check CAN_ESR_EPVF bit */
-        itstatus = CheckITStatus(CANx->ESR, CAN_ESR_EPVF);  
+        itstatus = CheckITStatus(CANx->ESR, CAN_ESR_EPVF);
         break;
       case CAN_IT_BOF:
         /* Check CAN_ESR_BOFF bit */
-        itstatus = CheckITStatus(CANx->ESR, CAN_ESR_BOFF);  
+        itstatus = CheckITStatus(CANx->ESR, CAN_ESR_BOFF);
         break;
       case CAN_IT_LEC:
         /* Check CAN_ESR_LEC bit */
-        itstatus = CheckITStatus(CANx->ESR, CAN_ESR_LEC);  
+        itstatus = CheckITStatus(CANx->ESR, CAN_ESR_LEC);
         break;
       case CAN_IT_ERR:
-        /* Check CAN_MSR_ERRI bit */ 
-        itstatus = CheckITStatus(CANx->MSR, CAN_MSR_ERRI); 
+        /* Check CAN_MSR_ERRI bit */
+        itstatus = CheckITStatus(CANx->MSR, CAN_MSR_ERRI);
         break;
       default:
         /* in case of error, return RESET */
@@ -1495,7 +1495,7 @@ ITStatus CAN_GetITStatus(CAN_TypeDef* CANx, uint32_t CAN_IT)
    /* in case the Interrupt is not enabled, return RESET */
     itstatus  = RESET;
   }
-  
+
   /* Return the CAN_IT status */
   return  itstatus;
 }
@@ -1511,12 +1511,12 @@ ITStatus CAN_GetITStatus(CAN_TypeDef* CANx, uint32_t CAN_IT)
   *            @arg CAN_IT_FF1: FIFO 1 full Interrupt
   *            @arg CAN_IT_FOV1: FIFO 1 overrun Interrupt
   *            @arg CAN_IT_WKU: Wake-up Interrupt
-  *            @arg CAN_IT_SLK: Sleep acknowledge Interrupt  
+  *            @arg CAN_IT_SLK: Sleep acknowledge Interrupt
   *            @arg CAN_IT_EWG: Error warning Interrupt
   *            @arg CAN_IT_EPV: Error passive Interrupt
-  *            @arg CAN_IT_BOF: Bus-off Interrupt  
+  *            @arg CAN_IT_BOF: Bus-off Interrupt
   *            @arg CAN_IT_LEC: Last error code Interrupt
-  *            @arg CAN_IT_ERR: Error Interrupt 
+  *            @arg CAN_IT_ERR: Error Interrupt
   * @retval None
   */
 void CAN_ClearITPendingBit(CAN_TypeDef* CANx, uint32_t CAN_IT)
@@ -1529,58 +1529,58 @@ void CAN_ClearITPendingBit(CAN_TypeDef* CANx, uint32_t CAN_IT)
   {
     case CAN_IT_TME:
       /* Clear CAN_TSR_RQCPx (rc_w1)*/
-      CANx->TSR = CAN_TSR_RQCP0|CAN_TSR_RQCP1|CAN_TSR_RQCP2;  
+      CANx->TSR = CAN_TSR_RQCP0|CAN_TSR_RQCP1|CAN_TSR_RQCP2;
       break;
     case CAN_IT_FF0:
       /* Clear CAN_RF0R_FULL0 (rc_w1)*/
-      CANx->RF0R = CAN_RF0R_FULL0; 
+      CANx->RF0R = CAN_RF0R_FULL0;
       break;
     case CAN_IT_FOV0:
       /* Clear CAN_RF0R_FOVR0 (rc_w1)*/
-      CANx->RF0R = CAN_RF0R_FOVR0; 
+      CANx->RF0R = CAN_RF0R_FOVR0;
       break;
     case CAN_IT_FF1:
       /* Clear CAN_RF1R_FULL1 (rc_w1)*/
-      CANx->RF1R = CAN_RF1R_FULL1;  
+      CANx->RF1R = CAN_RF1R_FULL1;
       break;
     case CAN_IT_FOV1:
       /* Clear CAN_RF1R_FOVR1 (rc_w1)*/
-      CANx->RF1R = CAN_RF1R_FOVR1; 
+      CANx->RF1R = CAN_RF1R_FOVR1;
       break;
     case CAN_IT_WKU:
       /* Clear CAN_MSR_WKUI (rc_w1)*/
-      CANx->MSR = CAN_MSR_WKUI;  
+      CANx->MSR = CAN_MSR_WKUI;
       break;
     case CAN_IT_SLK:
-      /* Clear CAN_MSR_SLAKI (rc_w1)*/ 
-      CANx->MSR = CAN_MSR_SLAKI;   
+      /* Clear CAN_MSR_SLAKI (rc_w1)*/
+      CANx->MSR = CAN_MSR_SLAKI;
       break;
     case CAN_IT_EWG:
       /* Clear CAN_MSR_ERRI (rc_w1) */
       CANx->MSR = CAN_MSR_ERRI;
-       /* @note the corresponding Flag is cleared by hardware depending on the CAN Bus status*/ 
+       /* @note the corresponding Flag is cleared by hardware depending on the CAN Bus status*/
       break;
     case CAN_IT_EPV:
       /* Clear CAN_MSR_ERRI (rc_w1) */
-      CANx->MSR = CAN_MSR_ERRI; 
+      CANx->MSR = CAN_MSR_ERRI;
        /* @note the corresponding Flag is cleared by hardware depending on the CAN Bus status*/
       break;
     case CAN_IT_BOF:
-      /* Clear CAN_MSR_ERRI (rc_w1) */ 
-      CANx->MSR = CAN_MSR_ERRI; 
+      /* Clear CAN_MSR_ERRI (rc_w1) */
+      CANx->MSR = CAN_MSR_ERRI;
        /* @note the corresponding Flag is cleared by hardware depending on the CAN Bus status*/
        break;
     case CAN_IT_LEC:
       /*  Clear LEC bits */
-      CANx->ESR = RESET; 
+      CANx->ESR = RESET;
       /* Clear CAN_MSR_ERRI (rc_w1) */
-      CANx->MSR = CAN_MSR_ERRI; 
+      CANx->MSR = CAN_MSR_ERRI;
       break;
     case CAN_IT_ERR:
       /*Clear LEC bits */
-      CANx->ESR = RESET; 
+      CANx->ESR = RESET;
       /* Clear CAN_MSR_ERRI (rc_w1) */
-      CANx->MSR = CAN_MSR_ERRI; 
+      CANx->MSR = CAN_MSR_ERRI;
        /* @note BOFF, EPVF and EWGF Flags are cleared by hardware depending on the CAN Bus status*/
        break;
     default:
@@ -1600,7 +1600,7 @@ void CAN_ClearITPendingBit(CAN_TypeDef* CANx, uint32_t CAN_IT)
 static ITStatus CheckITStatus(uint32_t CAN_Reg, uint32_t It_Bit)
 {
   ITStatus pendingbitstatus = RESET;
-  
+
   if ((CAN_Reg & It_Bit) != (uint32_t)RESET)
   {
     /* CAN_IT is set */


### PR DESCRIPTION
file stm32f10x.h had 'receive' spelled wrong on line 8209
file stm32f30x_can.c had a mis-spelled 'CAN_RECEIVE()' function name in notes about it on line 36, but the actual function call at around line 720-ish spells 'receive' correctly.

all other line changes were text editor auto-removals of white space.